### PR TITLE
PORI-X - Remove driveturku layout dependecy from features

### DIFF
--- a/code/modules/features/kada_configuration_feature/kada_configuration_feature.context.inc
+++ b/code/modules/features/kada_configuration_feature/kada_configuration_feature.context.inc
@@ -154,7 +154,6 @@ function kada_configuration_feature_context_default_contexts() {
           'weight' => '-10',
         ),
       ),
-      'layout' => 'kada-front',
     ),
   );
   $context->condition_mode = 1;
@@ -236,7 +235,6 @@ function kada_configuration_feature_context_default_contexts() {
           'weight' => '-8',
         ),
       ),
-      'layout' => 'driveturku-default',
     ),
   );
   $context->condition_mode = 1;
@@ -505,7 +503,6 @@ function kada_configuration_feature_context_default_contexts() {
           'weight' => '-8',
         ),
       ),
-      'layout' => 'driveturku-default',
     ),
   );
   $context->condition_mode = 1;

--- a/code/modules/features/kada_configuration_feature/kada_configuration_feature.features.fe_block_settings.inc
+++ b/code/modules/features/kada_configuration_feature/kada_configuration_feature.features.fe_block_settings.inc
@@ -31,6 +31,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -59,6 +65,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'region' => '',
         'status' => 0,
         'theme' => 'kada',
+        'weight' => 0,
+      ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
         'weight' => 0,
       ),
       'seven' => array(
@@ -91,6 +103,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -119,6 +137,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'region' => '',
         'status' => 0,
         'theme' => 'kada',
+        'weight' => 0,
+      ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
         'weight' => 0,
       ),
       'seven' => array(
@@ -151,6 +175,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -181,6 +211,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -207,6 +243,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'region' => '',
         'status' => 0,
         'theme' => 'kada',
+        'weight' => 0,
+      ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
         'weight' => 0,
       ),
       'seven' => array(
@@ -237,6 +279,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -263,6 +311,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'region' => '',
         'status' => 0,
         'theme' => 'kada',
+        'weight' => 0,
+      ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
         'weight' => 0,
       ),
       'seven' => array(
@@ -295,6 +349,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -323,6 +383,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'region' => '',
         'status' => 0,
         'theme' => 'kada',
+        'weight' => 0,
+      ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
         'weight' => 0,
       ),
       'seven' => array(
@@ -355,6 +421,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -385,6 +457,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -413,6 +491,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -439,6 +523,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'region' => '',
         'status' => 0,
         'theme' => 'kada',
+        'weight' => 0,
+      ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
         'weight' => 0,
       ),
       'seven' => array(
@@ -471,6 +561,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -499,6 +595,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'region' => '',
         'status' => 0,
         'theme' => 'kada',
+        'weight' => 0,
+      ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
         'weight' => 0,
       ),
       'seven' => array(
@@ -531,6 +633,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -559,6 +667,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'region' => '',
         'status' => 0,
         'theme' => 'kada',
+        'weight' => 0,
+      ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
         'weight' => 0,
       ),
       'seven' => array(
@@ -591,6 +705,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -617,6 +737,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'region' => '',
         'status' => 0,
         'theme' => 'kada',
+        'weight' => 0,
+      ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
         'weight' => 0,
       ),
       'seven' => array(
@@ -647,6 +773,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -675,6 +807,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -701,6 +839,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'region' => '',
         'status' => 0,
         'theme' => 'kada',
+        'weight' => 0,
+      ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
         'weight' => 0,
       ),
       'seven' => array(
@@ -733,6 +877,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -763,6 +913,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -789,6 +945,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'region' => '',
         'status' => 0,
         'theme' => 'kada',
+        'weight' => 0,
+      ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
         'weight' => 0,
       ),
       'seven' => array(
@@ -819,6 +981,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -845,6 +1013,12 @@ function kada_configuration_feature_default_fe_block_settings() {
         'region' => '',
         'status' => 0,
         'theme' => 'kada',
+        'weight' => 0,
+      ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
         'weight' => 0,
       ),
       'seven' => array(

--- a/code/modules/features/kada_geo_feature/kada_geo_feature.context.inc
+++ b/code/modules/features/kada_geo_feature/kada_geo_feature.context.inc
@@ -52,7 +52,6 @@ function kada_geo_feature_context_default_contexts() {
           'weight' => '-9',
         ),
       ),
-      'layout' => 'driveturku-front',
     ),
   );
   $context->condition_mode = 0;

--- a/code/modules/features/kada_landing_page_feature/kada_landing_page_feature.context.inc
+++ b/code/modules/features/kada_landing_page_feature/kada_landing_page_feature.context.inc
@@ -66,7 +66,6 @@ function kada_landing_page_feature_context_default_contexts() {
           'weight' => '-10',
         ),
       ),
-      'layout' => 'driveturku-front',
     ),
     'theme_html' => array(
       'class' => 'landing-page',

--- a/code/modules/features/kada_liftups_feature/kada_liftups_feature.context.inc
+++ b/code/modules/features/kada_liftups_feature/kada_liftups_feature.context.inc
@@ -20,10 +20,15 @@ function kada_liftups_feature_context_default_contexts() {
     'entity_field' => array(
       'values' => array(
         'entity_type' => 'a:1:{s:4:"node";s:4:"node";}',
-        'view_mode' => 'a:39:{s:4:"full";s:4:"full";s:6:"teaser";i:0;s:3:"rss";i:0;s:13:"diff_standard";i:0;s:5:"token";i:0;s:9:"accordion";i:0;s:8:"carousel";i:0;s:7:"current";i:0;s:7:"project";i:0;s:13:"search_result";i:0;s:15:"event_grid_item";i:0;s:15:"event_list_item";i:0;s:14:"event_map_item";i:0;s:17:"event_mosaic_item";i:0;s:19:"event_search_result";i:0;s:19:"event_tab_list_item";i:0;s:18:"event_top_carousel";i:0;s:9:"main_news";i:0;s:14:"main_news_wide";i:0;s:10:"only_title";i:0;s:3:"map";i:0;s:8:"revision";i:0;s:10:"label_icon";i:0;s:9:"term_name";i:0;s:5:"title";i:0;s:12:"content_full";i:0;s:12:"content_half";i:0;s:6:"topics";i:0;s:16:"main_liftup_wide";i:0;s:11:"main_liftup";i:0;s:12:"main_content";i:0;s:10:"full_modal";i:0;s:10:"event_list";i:0;s:9:"grid_item";i:0;s:10:"event_node";i:0;s:14:"event_tab_item";i:0;s:6:"person";i:0;s:17:"file_linked_title";i:0;s:9:"opengraph";i:0;}',
+        'view_mode' => 'a:39:{s:4:"full";s:4:"full";s:6:"teaser";i:0;s:3:"rss";i:0;s:13:"diff_standard";i:0;s:5:"token";i:0;s:3:"map";i:0;s:9:"main_news";i:0;s:14:"main_news_wide";i:0;s:10:"only_title";i:0;s:15:"event_grid_item";i:0;s:15:"event_list_item";i:0;s:14:"event_map_item";i:0;s:17:"event_mosaic_item";i:0;s:19:"event_search_result";i:0;s:19:"event_tab_list_item";i:0;s:18:"event_top_carousel";i:0;s:9:"accordion";i:0;s:8:"carousel";i:0;s:7:"current";i:0;s:7:"project";i:0;s:8:"revision";i:0;s:10:"label_icon";i:0;s:9:"term_name";i:0;s:5:"title";i:0;s:12:"content_full";i:0;s:12:"content_half";i:0;s:6:"topics";i:0;s:16:"main_liftup_wide";i:0;s:11:"main_liftup";i:0;s:12:"main_content";i:0;s:10:"full_modal";i:0;s:10:"event_list";i:0;s:9:"grid_item";i:0;s:10:"event_node";i:0;s:14:"event_tab_item";i:0;s:6:"person";i:0;s:17:"file_linked_title";i:0;s:13:"search_result";i:0;s:9:"opengraph";i:0;}',
         'field_name' => 'field_theme_main_page',
         'field_status' => 'match',
         'field_value' => '1',
+      ),
+    ),
+    'path' => array(
+      'values' => array(
+        '~<front>' => '~<front>',
       ),
     ),
   );
@@ -67,18 +72,16 @@ function kada_liftups_feature_context_default_contexts() {
           'weight' => '-8',
         ),
         'views-kada_project_liftups-block' => array(
-           'module' => 'views',
-           'delta' => 'kada_project_liftups-block',
-           'region' => 'before_footer',
-           'weight' => '-10',
+          'module' => 'views',
+          'delta' => 'kada_project_liftups-block',
+          'region' => 'before_footer',
+          'weight' => '-10',
         ),
       ),
-      'layout' => 'driveturku-front',
     ),
     'region' => array(
-      'driveturku' => array(
+      'kada' => array(
         'disable' => array(
-          'sidebar_first' => 'sidebar_first',
           'emergency_messages' => 0,
           'before_header' => 0,
           'branding' => 0,
@@ -92,6 +95,7 @@ function kada_liftups_feature_context_default_contexts() {
           'help' => 0,
           'tools_container' => 0,
           'content' => 0,
+          'sidebar_first' => 0,
           'sidebar_second' => 0,
           'before_content' => 0,
           'after_content' => 0,
@@ -102,6 +106,28 @@ function kada_liftups_feature_context_default_contexts() {
           'event_list' => 0,
           'event_map' => 0,
           'filters' => 0,
+        ),
+      ),
+      'omega' => array(
+        'disable' => array(
+          'branding' => 0,
+          'header' => 0,
+          'navigation' => 0,
+          'highlighted' => 0,
+          'help' => 0,
+          'content' => 0,
+          'sidebar_first' => 0,
+          'sidebar_second' => 0,
+          'footer' => 0,
+        ),
+      ),
+      'seven' => array(
+        'disable' => array(
+          'content' => 0,
+          'help' => 0,
+          'page_top' => 0,
+          'page_bottom' => 0,
+          'sidebar_first' => 0,
         ),
       ),
     ),

--- a/code/modules/features/kada_liftups_feature/kada_liftups_feature.features.fe_block_settings.inc
+++ b/code/modules/features/kada_liftups_feature/kada_liftups_feature.features.fe_block_settings.inc
@@ -29,6 +29,12 @@ function kada_liftups_feature_default_fe_block_settings() {
         'theme' => 'kada',
         'weight' => 0,
       ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
+        'weight' => 0,
+      ),
       'seven' => array(
         'region' => '',
         'status' => 0,
@@ -55,6 +61,12 @@ function kada_liftups_feature_default_fe_block_settings() {
         'region' => '',
         'status' => 0,
         'theme' => 'kada',
+        'weight' => 0,
+      ),
+      'omega' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'omega',
         'weight' => 0,
       ),
       'seven' => array(

--- a/code/modules/features/kada_page_feature/kada_page_feature.context.inc
+++ b/code/modules/features/kada_page_feature/kada_page_feature.context.inc
@@ -177,7 +177,6 @@ function kada_page_feature_context_default_contexts() {
           'weight' => '-10',
         ),
       ),
-      'layout' => 'driveturku-default',
     ),
   );
   $context->condition_mode = 1;

--- a/code/modules/features/kada_sections_feature/kada_sections_feature.context.inc
+++ b/code/modules/features/kada_sections_feature/kada_sections_feature.context.inc
@@ -191,7 +191,6 @@ function kada_sections_feature_context_default_contexts() {
           'weight' => '-9',
         ),
       ),
-      'layout' => 'driveturku-front',
     ),
     'theme_html' => array(
       'class' => 'theme-front',

--- a/conf/drushmake.yml
+++ b/conf/drushmake.yml
@@ -387,6 +387,8 @@ projects:
     version: '1.5'
   search_api:
     version: '1.22'
+  search_api_ajax:
+    version: '1.2'
   search_api_et:
     type: module
     download:


### PR DESCRIPTION
To test:

1. drush fra -y && drush cc all
2. Go to front page and any other page on the sites navigation and make sure that you can see the layout with Pori logo. This means that all the contexts are using correct layout and Driveturku theme is no longer refered anywhere.