### PR TITLE
Change hotjar tracking id to staging

### DIFF
--- a/drupal/code/modules/features/pori_configuration/pori_configuration.strongarm.inc
+++ b/drupal/code/modules/features/pori_configuration/pori_configuration.strongarm.inc
@@ -15,7 +15,7 @@ function pori_configuration_strongarm() {
   $strongarm->api_version = 1;
   $strongarm->name = 'hotjar_settings';
   $strongarm->value = array(
-    'hotjar_account' => '673361',
+    'hotjar_account' => '673332',
     'hotjar_visibility_pages' => '0',
     'hotjar_pages' => 'admin
 admin/*


### PR DESCRIPTION
Use the correct id for the staging environment as
the hotjar tracking id. Might want to specify environment
specific overrides in settings files later.