### PR TITLE
Fix menu autoheights

### DIFF
--- a/drupal/code/themes/custom/kada/dist/js/kada.behaviors.min.js
+++ b/drupal/code/themes/custom/kada/dist/js/kada.behaviors.min.js
@@ -234,6 +234,7 @@
               highest = rightHeight;
             }
             $(elem).css('height', highest);
+            $(elem).find('.menu:visible').css('height', highest);
             switchMainMenuBehavior(context);
           }
         }

--- a/drupal/code/themes/custom/kada/src/js/kada.behaviors.js
+++ b/drupal/code/themes/custom/kada/src/js/kada.behaviors.js
@@ -234,6 +234,7 @@
               highest = rightHeight;
             }
             $(elem).css('height', highest);
+            $(elem).find('.menu:visible').css('height', highest);
             switchMainMenuBehavior(context);
           }
         }


### PR DESCRIPTION
Max out the third level menu height as well. If the
third level is short enough to have the bottom
above its parent second level item, trying to move
the cursor into the third level would cause the
menu to close, making it unreachable.