### PR TITLE
Patched Openlayers, fixing fatal error editing quicktabs

### DIFF
--- a/drupal/conf/kadaproject.make
+++ b/drupal/conf/kadaproject.make
@@ -412,6 +412,7 @@ projects[openlayers][version] = 2.0-beta11
 projects[openlayers][subdir] = contrib
 ; Patch for internal original variant for 2.0-beta11 version, should be fixed in -dev version already
 projects[openlayers][patch][] = "../patches/openlayers_internal_variant.patch"
+projects[openlayers][patch][] = "https://www.drupal.org/files/issues/0001-Issue-2888123-QuickMap-Plugin-for-Quicktabs-Causes-F.patch"
 
 projects[openlayers_geolocate_button][version] = 1.0
 projects[openlayers_geolocate_button][subdir] = contrib


### PR DESCRIPTION
Quickmap plugin for quicktabs caused fatal errors when
editing quicktabs.