### PR TITLE
Enable google analytics

### DIFF
--- a/drupal/code/profiles/kadaprofile/kadaprofile.profile
+++ b/drupal/code/profiles/kadaprofile/kadaprofile.profile
@@ -177,3 +177,15 @@ function kadaprofile_update_7112() {
   module_disable($modules, $enable_dependencies);
   drupal_uninstall_modules($modules);
 }
+
+/**
+ * Implements hook_update().
+ *
+ * Enable Google Analytics
+ */
+function kadaprofile_update_7113() {
+  $modules = array('googleanalytics');
+  $enable_dependencies = TRUE;
+
+  module_enable($modules, $enable_dependencies);
+}

--- a/drupal/conf/settings.php
+++ b/drupal/conf/settings.php
@@ -70,18 +70,21 @@ switch ($env) {
       $conf['simple_environment_indicator'] = '#e56716 Stage';
       $conf['file_private_path'] = '/var/www/pori.stage.wunder.io/private_files';
       $conf['file_temporary_path'] = '/var/www/pori.stage.wunder.io/tmp';
+      $conf['googleanalytics_account'] = ''; // Make sure the GA isn't enabled in this env
     break;
 
     case 'dev':
       $conf['simple_environment_indicator'] = '#004984 Development';
       $conf['file_private_path'] = '/var/www/pori.dev.wunder.io/private_files';
       $conf['file_temporary_path'] = '/var/www/pori.stage.wunder.io/tmp';
+      $conf['googleanalytics_account'] = ''; // Make sure the GA isn't enabled in this env
     break;
 
     case 'local':
       $conf['simple_environment_indicator'] = '#88b700 Local';
       $conf['preprocess_css'] = false;
       $conf['preprocess_js'] = false;
+      $conf['googleanalytics_account'] = ''; // Make sure the GA isn't enabled in this env
     break;
 }
 


### PR DESCRIPTION
1) Execute 'drush updb' 
2) Go to http://local.pori.fi/admin/config/system/googleanalytics and try to save UA-123456 in the 'Web Property ID' field.
3) Reload http://local.pori.fi/admin/config/system/googleanalytics => 'Web Property ID' should be empty (because forced setting of the variable in local/dev/stage environment)