### PR TITLE
PORI-X: Allow selecting the VisitPori menus as the menu link for a page

### DIFF
--- a/drupal/code/modules/features/pori_attraction_feature/pori_attraction_feature.info
+++ b/drupal/code/modules/features/pori_attraction_feature/pori_attraction_feature.info
@@ -26,6 +26,7 @@ dependencies[] = openlayers
 dependencies[] = openlayers_views
 dependencies[] = options
 dependencies[] = picture
+dependencies[] = pori_visitpori_override_feature
 dependencies[] = relation_add
 dependencies[] = restrict_node_page_view
 dependencies[] = service_links

--- a/drupal/code/modules/features/pori_attraction_feature/pori_attraction_feature.install
+++ b/drupal/code/modules/features/pori_attraction_feature/pori_attraction_feature.install
@@ -189,12 +189,21 @@ function pori_attraction_feature_update_7007(&$sandbox) {
 }
 
 /**
+ * Enable the override module.
+ */
+function pori_attraction_feature_update_7008(&$sandbox) {
+  module_enable(array('pori_visitpori_override_feature'));
+}
+
+/**
+ * Delete attraction category instance from the field collection.
+/**
  * Set i18n_mode to Attraction category, Accessibility and Bus lines vocabularies.
  */
 /*
  // THIS UPDATE HOOK WILL WAIT UNTIL THE PRODUCTION SITE HAS THIS MODULE ENABLED.
  // SETTING THE i18n_mode AT THE SAME TIME WHEN CREATING THE VOCABULARY DOESN'T WORK FOR SOME REASON.
-function pori_attraction_feature_update_7008(&$sandbox) {
+function pori_attraction_feature_update_7009(&$sandbox) {
   $voc_machine_names = array('attraction_category', 'accessibility', 'bus_lines');
   foreach ($voc_machine_names as $machine_name) {
     $voc = taxonomy_vocabulary_machine_name_load($machine_name);

--- a/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.features.features_overrides.inc
+++ b/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.features.features_overrides.inc
@@ -12,6 +12,7 @@ function pori_visitpori_override_feature_features_override_default_overrides() {
   $overrides = array();
 
   // Exported overrides for: variable
+  $overrides["variable.menu_options_page.value|10"] = 'menu-visitpori-footer-menu-en';
   $overrides["variable.menu_options_page.value|11"] = 'menu-visitpori-footer-menu-fi';
   $overrides["variable.menu_options_page.value|12"] = 'menu-visitpori-main-navigation';
   $overrides["variable.menu_options_page.value|13"] = 'menu-visitpori-main-menu';

--- a/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.features.features_overrides.inc
+++ b/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.features.features_overrides.inc
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @file
+ * pori_visitpori_override_feature.features.features_overrides.inc
+ */
+
+/**
+ * Implements hook_features_override_default_overrides().
+ */
+function pori_visitpori_override_feature_features_override_default_overrides() {
+  // This code is only used for UI in features. Exported alters hooks do the magic.
+  $overrides = array();
+
+  // Exported overrides for: variable
+  $overrides["variable.menu_options_page.value|11"] = 'menu-visitpori-footer-menu-fi';
+  $overrides["variable.menu_options_page.value|12"] = 'menu-visitpori-main-navigation';
+  $overrides["variable.menu_options_page.value|13"] = 'menu-visitpori-main-menu';
+  $overrides["variable.menu_options_page.value|14"] = 'menu-visitpori-top-menu-en';
+  $overrides["variable.menu_options_page.value|15"] = 'menu-visitpori-top-menu-fi';
+
+ return $overrides;
+}

--- a/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.features.inc
+++ b/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.features.inc
@@ -9,6 +9,7 @@
  */
 function pori_visitpori_override_feature_strongarm_alter(&$data) {
   if (isset($data['menu_options_page'])) {
+    $data['menu_options_page']->value[10] = 'menu-visitpori-footer-menu-en'; /* WAS: '' */
     $data['menu_options_page']->value[11] = 'menu-visitpori-footer-menu-fi'; /* WAS: '' */
     $data['menu_options_page']->value[12] = 'menu-visitpori-main-navigation'; /* WAS: '' */
     $data['menu_options_page']->value[13] = 'menu-visitpori-main-menu'; /* WAS: '' */

--- a/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.features.inc
+++ b/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.features.inc
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @file
+ * pori_visitpori_override_feature.features.inc
+ */
+
+/**
+ * Implements hook_strongarm_alter().
+ */
+function pori_visitpori_override_feature_strongarm_alter(&$data) {
+  if (isset($data['menu_options_page'])) {
+    $data['menu_options_page']->value[11] = 'menu-visitpori-footer-menu-fi'; /* WAS: '' */
+    $data['menu_options_page']->value[12] = 'menu-visitpori-main-navigation'; /* WAS: '' */
+    $data['menu_options_page']->value[13] = 'menu-visitpori-main-menu'; /* WAS: '' */
+    $data['menu_options_page']->value[14] = 'menu-visitpori-top-menu-en'; /* WAS: '' */
+    $data['menu_options_page']->value[15] = 'menu-visitpori-top-menu-fi'; /* WAS: '' */
+  }
+}

--- a/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.info
+++ b/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.info
@@ -1,0 +1,10 @@
+name = VisitPori override feature
+core = 7.x
+package = Pori
+version = 7.x-1.0-dev
+features[features_api][] = api:2
+features[features_overrides][] = variable.menu_options_page.value|11
+features[features_overrides][] = variable.menu_options_page.value|12
+features[features_overrides][] = variable.menu_options_page.value|13
+features[features_overrides][] = variable.menu_options_page.value|14
+features[features_overrides][] = variable.menu_options_page.value|15

--- a/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.info
+++ b/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.info
@@ -3,6 +3,7 @@ core = 7.x
 package = Pori
 version = 7.x-1.0-dev
 features[features_api][] = api:2
+features[features_overrides][] = variable.menu_options_page.value|10
 features[features_overrides][] = variable.menu_options_page.value|11
 features[features_overrides][] = variable.menu_options_page.value|12
 features[features_overrides][] = variable.menu_options_page.value|13

--- a/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.module
+++ b/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.module
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @file
+ * Code for the VisitPori override feature feature.
+ */
+
+include_once 'pori_visitpori_override_feature.features.inc';


### PR DESCRIPTION
drush updb

This should allow one to select the VisitPori menus as parent of a menu link in page.