### PR TITLE
Fix for footer blocks in wrong order.

### DIFF
--- a/drupal/code/modules/features/pori_configuration/pori_configuration.info
+++ b/drupal/code/modules/features/pori_configuration/pori_configuration.info
@@ -6,6 +6,7 @@ version = 7.x-1.0
 dependencies[] = features
 dependencies[] = kada_configuration_feature
 dependencies[] = locale
+dependencies[] = pori_configuration_overrides_feature
 features[ctools][] = strongarm:strongarm:1
 features[features_api][] = api:2
 features[language][] = de

--- a/drupal/code/modules/features/pori_configuration/pori_configuration.install
+++ b/drupal/code/modules/features/pori_configuration/pori_configuration.install
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Enable the overrides module.
+ */
+function pori_configuration_update_7100(&$sandbox) {
+  module_enable(array('pori_configuration_overrides_feature'));
+}

--- a/drupal/code/modules/features/pori_configuration_overrides_feature/pori_configuration_overrides_feature.features.features_overrides.inc
+++ b/drupal/code/modules/features/pori_configuration_overrides_feature/pori_configuration_overrides_feature.features.features_overrides.inc
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @file
+ * pori_configuration_overrides_feature.features.features_overrides.inc
+ */
+
+/**
+ * Implements hook_features_override_default_overrides().
+ */
+function pori_configuration_overrides_feature_features_override_default_overrides() {
+  // This code is only used for UI in features. Exported alters hooks do the magic.
+  $overrides = array();
+
+  // Exported overrides for: context
+  $overrides["context.sitewide_en.reactions|block|blocks|block-1|weight"] = -40;
+  $overrides["context.sitewide_fi.reactions|block|blocks|block-2|weight"] = -40;
+
+ return $overrides;
+}

--- a/drupal/code/modules/features/pori_configuration_overrides_feature/pori_configuration_overrides_feature.features.inc
+++ b/drupal/code/modules/features/pori_configuration_overrides_feature/pori_configuration_overrides_feature.features.inc
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @file
+ * pori_configuration_overrides_feature.features.inc
+ */
+
+/**
+ * Implements hook_context_default_contexts_alter().
+ */
+function pori_configuration_overrides_feature_context_default_contexts_alter(&$data) {
+  if (isset($data['sitewide_en'])) {
+    $data['sitewide_en']->reactions['block']['blocks']['block-1']['weight'] = -40; /* WAS: -10 */
+  }
+  if (isset($data['sitewide_fi'])) {
+    $data['sitewide_fi']->reactions['block']['blocks']['block-2']['weight'] = -40; /* WAS: -10 */
+  }
+}

--- a/drupal/code/modules/features/pori_configuration_overrides_feature/pori_configuration_overrides_feature.info
+++ b/drupal/code/modules/features/pori_configuration_overrides_feature/pori_configuration_overrides_feature.info
@@ -1,0 +1,7 @@
+name = Pori configuration overrides
+core = 7.x
+package = Pori
+version = 7.x-1.0-dev
+features[features_api][] = api:2
+features[features_overrides][] = context.sitewide_en.reactions|block|blocks|block-1|weight
+features[features_overrides][] = context.sitewide_fi.reactions|block|blocks|block-2|weight

--- a/drupal/code/modules/features/pori_configuration_overrides_feature/pori_configuration_overrides_feature.module
+++ b/drupal/code/modules/features/pori_configuration_overrides_feature/pori_configuration_overrides_feature.module
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @file
+ * Code for the Pori configuration overrides feature.
+ */
+
+include_once 'pori_configuration_overrides_feature.features.inc';


### PR DESCRIPTION
drush updb; drush cc all

Footer blocks should now be in the correct order (contact information leftmost, then navigation)