### PR TITLE
Disable entity translation patch for linkit as it breaks the search f…

### DIFF
--- a/drupal/conf/kadaproject.make
+++ b/drupal/conf/kadaproject.make
@@ -394,7 +394,7 @@ projects[linkchecker][subdir] = contrib
 projects[linkit][version] = 3.5
 projects[linkit][subdir] = "contrib"
 ; Entity translation support
-projects[linkit][patch][] = "https://www.drupal.org/files/issues/entity_translation-2280441-31.patch"
+;projects[linkit][patch][] = "https://www.drupal.org/files/issues/entity_translation-2280441-31.patch"
 
 projects[maxlength][version] = 3.2
 projects[maxlength][subdir] = contrib


### PR DESCRIPTION
…or some user roles

- The issue can be resolved by simply using the linkit tool instead of the regular link. Linkit also provides automatic id fetching by node title, so usability is far superior.
- Commented out the linkit entity translation patch because the search returns 500 errors as a web journalist user. This is not the case for uid 1, though, but I did not debug the cause of this as the scope was to get working internal linking in the first place.