### PR TITLE
Enable transliteration module

### DIFF
--- a/drupal/code/profiles/kadaprofile/kadaprofile.profile
+++ b/drupal/code/profiles/kadaprofile/kadaprofile.profile
@@ -221,3 +221,14 @@ function kadaprofile_update_7116() {
   $enable_dependencies = TRUE;
   module_enable($modules, $enable_dependencies);
 }
+
+/**
+ * Implements hook_update().
+ *
+ * Enables Transliteration module
+ */
+function kadaprofile_update_7117() {
+  $modules = array('transliteration');
+  $enable_dependencies = TRUE;
+  module_enable($modules, $enable_dependencies);
+}


### PR DESCRIPTION
- drush updb
- The "Transliterate prior to creating alias" should be checked at admin/config/search/path/settings (not because of the update hook but by default when the module is enabled)
- Go to admin/config/search/path/delete_bulk, check content and hit delete.
- Go to admin/config/search/path/update_bulk, check content paths and hit update.
- New and existing nodes with umlauts in the title should have transliterated paths.