### PR TITLE
PORI-221: Keywords broke landing-page slideshow

### DIFF
--- a/drupal/code/modules/features/kada_liftups_feature/kada_liftups_feature.views_default.inc
+++ b/drupal/code/modules/features/kada_liftups_feature/kada_liftups_feature.views_default.inc
@@ -3570,6 +3570,7 @@ function kada_liftups_feature_views_default_views() {
   $handler->display->display_options['arguments']['field_target_audience_tid']['default_argument_type'] = 'taxonomy_tid';
   $handler->display->display_options['arguments']['field_target_audience_tid']['default_argument_options']['term_page'] = FALSE;
   $handler->display->display_options['arguments']['field_target_audience_tid']['default_argument_options']['node'] = TRUE;
+  $handler->display->display_options['arguments']['field_target_audience_tid']['default_argument_options']['limit'] = TRUE;
   $handler->display->display_options['arguments']['field_target_audience_tid']['default_argument_options']['vocabularies'] = array(
     'target_audience' => 'target_audience',
   );


### PR DESCRIPTION
Keywords breaking landing page slideshow. Carousel was missing a one checkbox that limited the filter to taxonomy correctly.

To test:
1. drush fra -y && drush cc all
2. create landing-page with an target audience, then liftup with that same audience and flagit to carousel
3. make sure you added keywords to the landing-page
4. confirm that liftup or liftups are visible on the page