### PR TITLE
PORI-251 Removed the sidebar from front pages

### DIFF
--- a/drupal/code/themes/custom/kada/ds_layouts/page_layout/page-layout.tpl.php
+++ b/drupal/code/themes/custom/kada/ds_layouts/page_layout/page-layout.tpl.php
@@ -5,7 +5,7 @@
  * Page layout template
  */
 
-if (!empty($sidebar || $additional_information)) {
+if (!empty($sidebar || $additional_information) && $variables['is_front'] != true) {
     $additional_classes="page--has-sidebar";
 }
 ?>
@@ -19,7 +19,7 @@ if (!empty($sidebar || $additional_information)) {
     <?php print $main_content; ?>
 </<?php print $main_content_wrapper ?>>
 
-<?php if (!empty($sidebar || $additional_information)): ?>
+<?php if (!empty($sidebar || $additional_information) && $variables['is_front'] != true): ?>
   <<?php print $sidebar_wrapper ?> class="page__sidebar <?php print $sidebar_classes; ?>">
     <?php print $sidebar; ?>
     <?php if (!empty($additional_information)): ?>

--- a/drupal/code/themes/custom/kada/ds_layouts/page_layout/page_layout.inc
+++ b/drupal/code/themes/custom/kada/ds_layouts/page_layout/page_layout.inc
@@ -10,7 +10,7 @@ function ds_page_layout() {
     'label' => t('Page layout'),
     'regions' => array(
       'main_content' => t('Content'),
-      'sidebar' => t('Sidebar'),
+      'sidebar' => t('Sidebar - Not used on front pages'),
       'additional_information' => t('Additional information'),
       'after_content' => t('After content'),
     ),


### PR DESCRIPTION
To test:

1. drush cc all
2. Go to front page and edit it. Add key words if there aren't any. Save the page and view it. The keywords shouldn't be visible anywhere on this page.
3. Go to visitpori front page and do the same thing and make sure the keywords are still not visible.
4. Go to normal page and add keywords and make sure they are visible on the sidebar.