### PR TITLE
PORI-X: Visitpori menu IE bug.

### DIFF
--- a/drupal/code/themes/custom/visitpori/dist/js/visitpori.behaviors.min.js
+++ b/drupal/code/themes/custom/visitpori/dist/js/visitpori.behaviors.min.js
@@ -168,6 +168,7 @@
             let elementOffset = $(element).offset().left;
             $(element).children('.menu').css('left', elementOffset + 'px');
             $(element).find('.menu:visible').children('.menu').css('left', elementOffset + 'px');
+            switchMainMenuBehavior(context);
           }
         };
 

--- a/drupal/code/themes/custom/visitpori/dist/js/visitpori.behaviors.min.js
+++ b/drupal/code/themes/custom/visitpori/dist/js/visitpori.behaviors.min.js
@@ -149,6 +149,7 @@
           if ($(window).width() >= '1025') {
             adjustHeight($(this).children('.menu'));
             adjustWidth($(this));
+            setHorisontalPosition($(this));
             if (event.type === 'mouseleave') {
               $('.menu__item--has-second-level').children('ul').removeClass('is-hidden');
             }
@@ -161,6 +162,14 @@
             adjustHeight($(this).parent('.menu'));
           }
         });
+
+        function setHorisontalPosition(element) {
+          if ($(window).width() >= '1025') {
+            let elementOffset = $(element).offset().left;
+            $(element).children('.menu').css('left', elementOffset + 'px');
+            $(element).find('.menu:visible').children('.menu').css('left', elementOffset + 'px');
+          }
+        };
 
 
         function adjustWidth(elem) {

--- a/drupal/code/themes/custom/visitpori/src/js/visitpori.behaviors.js
+++ b/drupal/code/themes/custom/visitpori/src/js/visitpori.behaviors.js
@@ -168,6 +168,7 @@
             let elementOffset = $(element).offset().left;
             $(element).children('.menu').css('left', elementOffset + 'px');
             $(element).find('.menu:visible').children('.menu').css('left', elementOffset + 'px');
+            switchMainMenuBehavior(context);
           }
         };
 

--- a/drupal/code/themes/custom/visitpori/src/js/visitpori.behaviors.js
+++ b/drupal/code/themes/custom/visitpori/src/js/visitpori.behaviors.js
@@ -149,6 +149,7 @@
           if ($(window).width() >= '1025') {
             adjustHeight($(this).children('.menu'));
             adjustWidth($(this));
+            setHorisontalPosition($(this));
             if (event.type === 'mouseleave') {
               $('.menu__item--has-second-level').children('ul').removeClass('is-hidden');
             }
@@ -161,6 +162,14 @@
             adjustHeight($(this).parent('.menu'));
           }
         });
+
+        function setHorisontalPosition(element) {
+          if ($(window).width() >= '1025') {
+            let elementOffset = $(element).offset().left;
+            $(element).children('.menu').css('left', elementOffset + 'px');
+            $(element).find('.menu:visible').children('.menu').css('left', elementOffset + 'px');
+          }
+        };
 
 
         function adjustWidth(elem) {


### PR DESCRIPTION
Visitpori main menus subitems did not line up with its parent in IE 11 or older. Added js to add inline style with subitems parents offset to line up subitems.

To test:
1. drush cc all
2. if possible test with IE browser that main menu in local.visitpori.fi works as intended.
3. if no IE available, at least check that menu still works in other browsers.