### PR TITLE
PORI-284 Enabled linkit

### DIFF
--- a/drupal/code/modules/features/pori_news/pori_news.features.field_instance.inc
+++ b/drupal/code/modules/features/pori_news/pori_news.features.field_instance.inc
@@ -82,9 +82,9 @@ function pori_news_field_default_field_instances() {
       'enable_tokens' => 1,
       'entity_translation_sync' => FALSE,
       'linkit' => array(
-        'button_text' => 'Search',
-        'enable' => 0,
-        'profile' => '',
+        'button_text' => 'Search internal content',
+        'enable' => 1,
+        'profile' => 'fields',
       ),
       'rel_remove' => 'default',
       'title' => 'optional',


### PR DESCRIPTION
To test:

1. drush fra -y && drush cc all
2. Go to news item and make sure that under the "additional information" tab there is "Search internal content" button that lets you link internal content to the link field.