### PR TITLE
PORI-270: Only show relevant target audiences in the news archive

### DIFF
--- a/drupal/code/modules/features/pori_news/pori_news.info
+++ b/drupal/code/modules/features/pori_news/pori_news.info
@@ -15,7 +15,6 @@ dependencies[] = kada_news_feature
 dependencies[] = kada_page_feature
 dependencies[] = link
 dependencies[] = pori_contact_information_feature
-dependencies[] = pori_news
 dependencies[] = views
 features[ctools][] = ds:ds:1
 features[ctools][] = field_group:field_group:1

--- a/drupal/code/modules/features/pori_news/pori_news.views_default.inc
+++ b/drupal/code/modules/features/pori_news/pori_news.views_default.inc
@@ -42,27 +42,7 @@ function pori_news_views_default_views() {
       'secondary_label' => 'Advanced options',
       'secondary_collapse_override' => '0',
     ),
-    'field_target_audience_tid' => array(
-      'bef_format' => 'bef_links',
-      'more_options' => array(
-        'bef_select_all_none' => FALSE,
-        'bef_collapsible' => 0,
-        'autosubmit' => 0,
-        'is_secondary' => 0,
-        'any_label' => '',
-        'bef_filter_description' => '',
-        'tokens' => array(
-          'available' => array(
-            0 => 'global_types',
-            1 => 'vocabulary',
-          ),
-        ),
-        'rewrite' => array(
-          'filter_rewrite_values' => '',
-        ),
-      ),
-    ),
-    'body_value' => array(
+    'combine' => array(
       'bef_format' => 'default',
       'more_options' => array(
         'autosubmit' => 0,
@@ -79,8 +59,8 @@ function pori_news_views_default_views() {
         ),
       ),
     ),
-    'created' => array(
-      'bef_format' => 'bef_datepicker',
+    'date_filter' => array(
+      'bef_format' => 'default',
       'more_options' => array(
         'autosubmit' => 0,
         'is_secondary' => 0,
@@ -117,14 +97,34 @@ function pori_news_views_default_views() {
         ),
       ),
     ),
+    'field_target_audience_tid' => array(
+      'bef_format' => 'bef_links',
+      'more_options' => array(
+        'bef_select_all_none' => FALSE,
+        'bef_collapsible' => 0,
+        'autosubmit' => 0,
+        'is_secondary' => 0,
+        'any_label' => '',
+        'bef_filter_description' => '',
+        'tokens' => array(
+          'available' => array(
+            0 => 'global_types',
+            1 => 'vocabulary',
+          ),
+        ),
+        'rewrite' => array(
+          'filter_rewrite_values' => '',
+        ),
+      ),
+    ),
   );
   $handler->display->display_options['pager']['type'] = 'full';
   $handler->display->display_options['pager']['options']['items_per_page'] = '10';
-  $handler->display->display_options['pager']['options']['expose']['items_per_page_label'] = 'Tuloksia sivulla';
-  $handler->display->display_options['pager']['options']['tags']['first'] = '« ensimmäinen';
-  $handler->display->display_options['pager']['options']['tags']['previous'] = '‹ edellinen';
-  $handler->display->display_options['pager']['options']['tags']['next'] = 'seuraava ›';
-  $handler->display->display_options['pager']['options']['tags']['last'] = 'viimeinen »';
+  $handler->display->display_options['pager']['options']['expose']['items_per_page_label'] = 'Results per page';
+  $handler->display->display_options['pager']['options']['tags']['first'] = '« first';
+  $handler->display->display_options['pager']['options']['tags']['previous'] = '‹ previous';
+  $handler->display->display_options['pager']['options']['tags']['next'] = 'next ›';
+  $handler->display->display_options['pager']['options']['tags']['last'] = 'last »';
   $handler->display->display_options['style_plugin'] = 'default';
   $handler->display->display_options['row_plugin'] = 'fields';
   $handler->display->display_options['row_options']['default_field_elements'] = FALSE;
@@ -291,6 +291,103 @@ function pori_news_views_default_views() {
 
   /* Display: Visitpori archive */
   $handler = $view->new_display('page', 'Visitpori archive', 'page_1');
+  $handler->display->display_options['defaults']['exposed_form'] = FALSE;
+  $handler->display->display_options['exposed_form']['type'] = 'better_exposed_filters';
+  $handler->display->display_options['exposed_form']['options']['submit_button'] = 'Apply';
+  $handler->display->display_options['exposed_form']['options']['reset_button_label'] = 'Return to defaults';
+  $handler->display->display_options['exposed_form']['options']['exposed_sorts_label'] = 'Organize';
+  $handler->display->display_options['exposed_form']['options']['sort_asc_label'] = 'Asc';
+  $handler->display->display_options['exposed_form']['options']['sort_desc_label'] = 'Desc';
+  $handler->display->display_options['exposed_form']['options']['autosubmit'] = TRUE;
+  $handler->display->display_options['exposed_form']['options']['bef'] = array(
+    'general' => array(
+      'input_required' => 0,
+      'text_input_required' => array(
+        'text_input_required' => array(
+          'value' => 'Select any filter and click on Apply to see results',
+          'format' => 'wysiwyg',
+        ),
+      ),
+      'allow_secondary' => 0,
+      'secondary_label' => 'Advanced options',
+      'secondary_collapse_override' => '0',
+    ),
+    'combine' => array(
+      'bef_format' => 'default',
+      'more_options' => array(
+        'autosubmit' => 0,
+        'is_secondary' => 0,
+        'any_label' => '',
+        'bef_filter_description' => '',
+        'tokens' => array(
+          'available' => array(
+            0 => 'global_types',
+          ),
+        ),
+        'rewrite' => array(
+          'filter_rewrite_values' => '',
+        ),
+      ),
+    ),
+    'date_filter' => array(
+      'bef_format' => 'default',
+      'more_options' => array(
+        'autosubmit' => 0,
+        'is_secondary' => 0,
+        'any_label' => '',
+        'bef_filter_description' => '',
+        'tokens' => array(
+          'available' => array(
+            0 => 'global_types',
+          ),
+        ),
+        'rewrite' => array(
+          'filter_rewrite_values' => '',
+        ),
+        'datepicker_options' => '',
+      ),
+    ),
+    'field_visitpori_theme_tid' => array(
+      'bef_format' => 'bef_links',
+      'more_options' => array(
+        'bef_select_all_none' => FALSE,
+        'bef_collapsible' => 0,
+        'autosubmit' => 0,
+        'is_secondary' => 0,
+        'any_label' => '',
+        'bef_filter_description' => '',
+        'tokens' => array(
+          'available' => array(
+            0 => 'global_types',
+            1 => 'vocabulary',
+          ),
+        ),
+        'rewrite' => array(
+          'filter_rewrite_values' => '',
+        ),
+      ),
+    ),
+    'field_target_audience_tid' => array(
+      'bef_format' => 'bef_links',
+      'more_options' => array(
+        'bef_select_all_none' => FALSE,
+        'bef_collapsible' => 0,
+        'autosubmit' => 0,
+        'is_secondary' => 0,
+        'any_label' => '',
+        'bef_filter_description' => '',
+        'tokens' => array(
+          'available' => array(
+            0 => 'global_types',
+            1 => 'vocabulary',
+          ),
+        ),
+        'rewrite' => array(
+          'filter_rewrite_values' => '',
+        ),
+      ),
+    ),
+  );
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
   /* Filter criterion: Content: Published */
@@ -358,17 +455,17 @@ function pori_news_views_default_views() {
   $handler->display->display_options['filters']['date_filter']['date_fields'] = array(
     'node.created' => 'node.created',
   );
-  /* Filter criterion: Content: Theme (field_theme) */
-  $handler->display->display_options['filters']['field_theme_tid']['id'] = 'field_theme_tid';
-  $handler->display->display_options['filters']['field_theme_tid']['table'] = 'field_data_field_theme';
-  $handler->display->display_options['filters']['field_theme_tid']['field'] = 'field_theme_tid';
-  $handler->display->display_options['filters']['field_theme_tid']['group'] = 1;
-  $handler->display->display_options['filters']['field_theme_tid']['exposed'] = TRUE;
-  $handler->display->display_options['filters']['field_theme_tid']['expose']['operator_id'] = 'field_theme_tid_op';
-  $handler->display->display_options['filters']['field_theme_tid']['expose']['label'] = 'Theme';
-  $handler->display->display_options['filters']['field_theme_tid']['expose']['operator'] = 'field_theme_tid_op';
-  $handler->display->display_options['filters']['field_theme_tid']['expose']['identifier'] = 'field_theme_tid';
-  $handler->display->display_options['filters']['field_theme_tid']['expose']['remember_roles'] = array(
+  /* Filter criterion: Content: Visitpori theme (field_visitpori_theme) */
+  $handler->display->display_options['filters']['field_visitpori_theme_tid']['id'] = 'field_visitpori_theme_tid';
+  $handler->display->display_options['filters']['field_visitpori_theme_tid']['table'] = 'field_data_field_visitpori_theme';
+  $handler->display->display_options['filters']['field_visitpori_theme_tid']['field'] = 'field_visitpori_theme_tid';
+  $handler->display->display_options['filters']['field_visitpori_theme_tid']['group'] = 1;
+  $handler->display->display_options['filters']['field_visitpori_theme_tid']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['field_visitpori_theme_tid']['expose']['operator_id'] = 'field_visitpori_theme_tid_op';
+  $handler->display->display_options['filters']['field_visitpori_theme_tid']['expose']['label'] = 'Visitpori theme (field_visitpori_theme)';
+  $handler->display->display_options['filters']['field_visitpori_theme_tid']['expose']['operator'] = 'field_visitpori_theme_tid_op';
+  $handler->display->display_options['filters']['field_visitpori_theme_tid']['expose']['identifier'] = 'field_visitpori_theme_tid';
+  $handler->display->display_options['filters']['field_visitpori_theme_tid']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
     4 => 0,
@@ -378,8 +475,8 @@ function pori_news_views_default_views() {
     5 => 0,
     6 => 0,
   );
-  $handler->display->display_options['filters']['field_theme_tid']['type'] = 'select';
-  $handler->display->display_options['filters']['field_theme_tid']['vocabulary'] = 'theme';
+  $handler->display->display_options['filters']['field_visitpori_theme_tid']['type'] = 'select';
+  $handler->display->display_options['filters']['field_visitpori_theme_tid']['vocabulary'] = 'visitpori_theme';
   /* Filter criterion: Field: Target audience (field_target_audience) */
   $handler->display->display_options['filters']['field_target_audience_tid']['id'] = 'field_target_audience_tid';
   $handler->display->display_options['filters']['field_target_audience_tid']['table'] = 'field_data_field_target_audience';
@@ -419,6 +516,7 @@ function pori_news_views_default_views() {
   $handler->display->display_options['filters']['current_all']['table'] = 'domain_access';
   $handler->display->display_options['filters']['current_all']['field'] = 'current_all';
   $handler->display->display_options['filters']['current_all']['value'] = '1';
+  $handler->display->display_options['filters']['current_all']['group'] = 1;
   $handler->display->display_options['path'] = 'visitpori-news-archive';
   $translatables['pori_news'] = array(
     t('Master'),
@@ -431,19 +529,20 @@ function pori_news_views_default_views() {
     t('Desc'),
     t('Select any filter and click on Apply to see results'),
     t('Advanced options'),
-    t('Tuloksia sivulla'),
+    t('Results per page'),
     t('- All -'),
     t('Offset'),
-    t('« ensimmäinen'),
-    t('‹ edellinen'),
-    t('seuraava ›'),
-    t('viimeinen »'),
+    t('« first'),
+    t('‹ previous'),
+    t('next ›'),
+    t('last »'),
     t('Search'),
     t('Date'),
     t('Theme'),
     t('Target audience'),
     t('General archive'),
     t('Visitpori archive'),
+    t('Visitpori theme (field_visitpori_theme)'),
   );
   $export['pori_news'] = $view;
 

--- a/drupal/code/modules/features/pori_news/pori_news.views_default.inc
+++ b/drupal/code/modules/features/pori_news/pori_news.views_default.inc
@@ -251,6 +251,15 @@ function pori_news_views_default_views() {
   $handler->display->display_options['filters']['field_target_audience_tid']['id'] = 'field_target_audience_tid';
   $handler->display->display_options['filters']['field_target_audience_tid']['table'] = 'field_data_field_target_audience';
   $handler->display->display_options['filters']['field_target_audience_tid']['field'] = 'field_target_audience_tid';
+  $handler->display->display_options['filters']['field_target_audience_tid']['value'] = array(
+    54 => '54',
+    55 => '55',
+    56 => '56',
+    57 => '57',
+    58 => '58',
+    60 => '60',
+    59 => '59',
+  );
   $handler->display->display_options['filters']['field_target_audience_tid']['group'] = 1;
   $handler->display->display_options['filters']['field_target_audience_tid']['exposed'] = TRUE;
   $handler->display->display_options['filters']['field_target_audience_tid']['expose']['operator_id'] = 'field_target_audience_tid_op';
@@ -267,6 +276,7 @@ function pori_news_views_default_views() {
     5 => 0,
     6 => 0,
   );
+  $handler->display->display_options['filters']['field_target_audience_tid']['expose']['reduce'] = TRUE;
   $handler->display->display_options['filters']['field_target_audience_tid']['type'] = 'select';
   $handler->display->display_options['filters']['field_target_audience_tid']['vocabulary'] = 'target_audience';
 

--- a/drupal/code/modules/features/pori_news/pori_news.views_default.inc
+++ b/drupal/code/modules/features/pori_news/pori_news.views_default.inc
@@ -279,10 +279,147 @@ function pori_news_views_default_views() {
   $handler->display->display_options['filters']['field_target_audience_tid']['expose']['reduce'] = TRUE;
   $handler->display->display_options['filters']['field_target_audience_tid']['type'] = 'select';
   $handler->display->display_options['filters']['field_target_audience_tid']['vocabulary'] = 'target_audience';
+  /* Filter criterion: Domain Access: Available on current domain */
+  $handler->display->display_options['filters']['current_all']['id'] = 'current_all';
+  $handler->display->display_options['filters']['current_all']['table'] = 'domain_access';
+  $handler->display->display_options['filters']['current_all']['field'] = 'current_all';
+  $handler->display->display_options['filters']['current_all']['value'] = '1';
 
-  /* Display: Page */
-  $handler = $view->new_display('page', 'Page', 'page');
+  /* Display: General archive */
+  $handler = $view->new_display('page', 'General archive', 'page');
   $handler->display->display_options['path'] = 'news-archive';
+
+  /* Display: Visitpori archive */
+  $handler = $view->new_display('page', 'Visitpori archive', 'page_1');
+  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
+  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'news_item' => 'news_item',
+  );
+  $handler->display->display_options['filters']['type']['group'] = 1;
+  /* Filter criterion: Global: Combine fields filter */
+  $handler->display->display_options['filters']['combine']['id'] = 'combine';
+  $handler->display->display_options['filters']['combine']['table'] = 'views';
+  $handler->display->display_options['filters']['combine']['field'] = 'combine';
+  $handler->display->display_options['filters']['combine']['operator'] = 'allwords';
+  $handler->display->display_options['filters']['combine']['group'] = 1;
+  $handler->display->display_options['filters']['combine']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['combine']['expose']['operator_id'] = 'combine_op';
+  $handler->display->display_options['filters']['combine']['expose']['label'] = 'Search';
+  $handler->display->display_options['filters']['combine']['expose']['operator'] = 'combine_op';
+  $handler->display->display_options['filters']['combine']['expose']['identifier'] = 'text';
+  $handler->display->display_options['filters']['combine']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    4 => 0,
+    8 => 0,
+    3 => 0,
+    7 => 0,
+    5 => 0,
+    6 => 0,
+  );
+  $handler->display->display_options['filters']['combine']['fields'] = array(
+    'title' => 'title',
+    'body' => 'body',
+  );
+  /* Filter criterion: Date: Date (node) */
+  $handler->display->display_options['filters']['date_filter']['id'] = 'date_filter';
+  $handler->display->display_options['filters']['date_filter']['table'] = 'node';
+  $handler->display->display_options['filters']['date_filter']['field'] = 'date_filter';
+  $handler->display->display_options['filters']['date_filter']['group'] = 1;
+  $handler->display->display_options['filters']['date_filter']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['date_filter']['expose']['operator_id'] = 'date_filter_op';
+  $handler->display->display_options['filters']['date_filter']['expose']['label'] = 'Date';
+  $handler->display->display_options['filters']['date_filter']['expose']['operator'] = 'date_filter_op';
+  $handler->display->display_options['filters']['date_filter']['expose']['identifier'] = 'date_filter';
+  $handler->display->display_options['filters']['date_filter']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    4 => 0,
+    8 => 0,
+    3 => 0,
+    7 => 0,
+    5 => 0,
+    6 => 0,
+  );
+  $handler->display->display_options['filters']['date_filter']['granularity'] = 'month';
+  $handler->display->display_options['filters']['date_filter']['year_range'] = '-3:+0';
+  $handler->display->display_options['filters']['date_filter']['date_fields'] = array(
+    'node.created' => 'node.created',
+  );
+  /* Filter criterion: Content: Theme (field_theme) */
+  $handler->display->display_options['filters']['field_theme_tid']['id'] = 'field_theme_tid';
+  $handler->display->display_options['filters']['field_theme_tid']['table'] = 'field_data_field_theme';
+  $handler->display->display_options['filters']['field_theme_tid']['field'] = 'field_theme_tid';
+  $handler->display->display_options['filters']['field_theme_tid']['group'] = 1;
+  $handler->display->display_options['filters']['field_theme_tid']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['field_theme_tid']['expose']['operator_id'] = 'field_theme_tid_op';
+  $handler->display->display_options['filters']['field_theme_tid']['expose']['label'] = 'Theme';
+  $handler->display->display_options['filters']['field_theme_tid']['expose']['operator'] = 'field_theme_tid_op';
+  $handler->display->display_options['filters']['field_theme_tid']['expose']['identifier'] = 'field_theme_tid';
+  $handler->display->display_options['filters']['field_theme_tid']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    4 => 0,
+    8 => 0,
+    3 => 0,
+    7 => 0,
+    5 => 0,
+    6 => 0,
+  );
+  $handler->display->display_options['filters']['field_theme_tid']['type'] = 'select';
+  $handler->display->display_options['filters']['field_theme_tid']['vocabulary'] = 'theme';
+  /* Filter criterion: Field: Target audience (field_target_audience) */
+  $handler->display->display_options['filters']['field_target_audience_tid']['id'] = 'field_target_audience_tid';
+  $handler->display->display_options['filters']['field_target_audience_tid']['table'] = 'field_data_field_target_audience';
+  $handler->display->display_options['filters']['field_target_audience_tid']['field'] = 'field_target_audience_tid';
+  $handler->display->display_options['filters']['field_target_audience_tid']['value'] = array(
+    1550 => '1550',
+    1551 => '1551',
+    1552 => '1552',
+    1294 => '1294',
+    1295 => '1295',
+    1553 => '1553',
+    1554 => '1554',
+    1299 => '1299',
+    1499 => '1499',
+  );
+  $handler->display->display_options['filters']['field_target_audience_tid']['group'] = 1;
+  $handler->display->display_options['filters']['field_target_audience_tid']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['field_target_audience_tid']['expose']['operator_id'] = 'field_target_audience_tid_op';
+  $handler->display->display_options['filters']['field_target_audience_tid']['expose']['label'] = 'Target audience';
+  $handler->display->display_options['filters']['field_target_audience_tid']['expose']['operator'] = 'field_target_audience_tid_op';
+  $handler->display->display_options['filters']['field_target_audience_tid']['expose']['identifier'] = 'field_target_audience_tid';
+  $handler->display->display_options['filters']['field_target_audience_tid']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    4 => 0,
+    8 => 0,
+    3 => 0,
+    7 => 0,
+    5 => 0,
+    6 => 0,
+  );
+  $handler->display->display_options['filters']['field_target_audience_tid']['expose']['reduce'] = TRUE;
+  $handler->display->display_options['filters']['field_target_audience_tid']['type'] = 'select';
+  $handler->display->display_options['filters']['field_target_audience_tid']['vocabulary'] = 'target_audience';
+  /* Filter criterion: Domain Access: Available on current domain */
+  $handler->display->display_options['filters']['current_all']['id'] = 'current_all';
+  $handler->display->display_options['filters']['current_all']['table'] = 'domain_access';
+  $handler->display->display_options['filters']['current_all']['field'] = 'current_all';
+  $handler->display->display_options['filters']['current_all']['value'] = '1';
+  $handler->display->display_options['path'] = 'visitpori-news-archive';
   $translatables['pori_news'] = array(
     t('Master'),
     t('News archive'),
@@ -305,7 +442,8 @@ function pori_news_views_default_views() {
     t('Date'),
     t('Theme'),
     t('Target audience'),
-    t('Page'),
+    t('General archive'),
+    t('Visitpori archive'),
   );
   $export['pori_news'] = $view;
 


### PR DESCRIPTION
drush fra -y

/news-archive should only show relevant taxonomy terms as filter options for target audience.