### PR TITLE
PORI-314 changed the context to refer to views instead of path

### DIFF
--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.context.inc
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.context.inc
@@ -17,10 +17,9 @@ function pori_contact_information_feature_context_default_contexts() {
   $context->description = 'Phone book of people';
   $context->tag = 'views';
   $context->conditions = array(
-    'path' => array(
+    'views' => array(
       'values' => array(
-        'phone-book' => 'phone-book',
-        'phone-book/*' => 'phone-book/*',
+        'pori_phone_book:page' => 'pori_phone_book:page',
       ),
     ),
   );


### PR DESCRIPTION
To test:

1. drush fra -y && drush cc all
2. Go to /phone-book and make sure header and footer are visible
3. Create path alias for phone-book, for example puhelinluettelo
4. Go to /puhelinluettelo and make sure that header footer are still visible there and it looks just like phone-book page.