### PR TITLE
PORI-312: Correct JSON path for Instagram image

### DIFF
--- a/drupal/code/modules/features/kada_some_content_feature/kada_some_content_feature.feeds_importer_default.inc
+++ b/drupal/code/modules/features/kada_some_content_feature/kada_some_content_feature.feeds_importer_default.inc
@@ -306,7 +306,7 @@ function kada_some_content_feature_feeds_importer_default() {
           ),
           'image' => array(
             'name' => 'Image',
-            'value' => 'images.standard_resolution',
+            'value' => 'images.standard_resolution.url',
             'debug' => 0,
             'weight' => '6',
           ),


### PR DESCRIPTION
drush fra -y; drush cc all

Instagram image import should now work.