### PR TITLE
PORI-267: New version of Entity action log, because the old one cause…

### DIFF
--- a/drupal/conf/kadaproject.make
+++ b/drupal/conf/kadaproject.make
@@ -258,7 +258,7 @@ projects[entityqueue][subdir] = contrib
 ; Adds export for entityqueue subqueues
 projects[entityqueue][patch][] = "../patches/entityqueue_subqueue_export.patch"
 
-projects[entity_action_log][version] = 1.0-beta1
+projects[entity_action_log][version] = 1.0-beta2
 projects[entity_action_log][subdir] = contrib
 
 ; Only dev version is available for entity_base_type module.


### PR DESCRIPTION
…d constant failing of contact import and scheduler crons

./build.sh update

Testing:
1. Schedule an article / page to be published on the next selectable time and mark the node unpublished.
2. Run drush elysia-cron scheduler_cron
3. Check that the cron run publishes the node and doesn't fail to an entity_action_log error.