### PR TITLE
PORI-290: Updating features from KADA/Turku.fi current version to get…

### DIFF
--- a/drupal/code/modules/features/pori_search/pori_search.module
+++ b/drupal/code/modules/features/pori_search/pori_search.module
@@ -5,3 +5,228 @@
  */
 
 include_once 'pori_search.features.inc';
+
+/**
+ * Implements hook_menu().
+ */
+function pori_search_menu() {
+  $items['admin/config/search/boost'] = array(
+    'title' => 'Search boosting',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('pori_search_boost_settings_form'),
+    'access arguments' => array('administer search_api'),
+    'type' => MENU_NORMAL_ITEM,
+  );
+
+  $items['admin/config/search/kada_search'] = array(
+    'title' => 'KADA search settings',
+    'description' => 'Custom settings for KADA search.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('pori_search_settings_form'),
+    'access arguments' => array('administer search_api'),
+    'type' => MENU_NORMAL_ITEM,
+  );
+
+  $items['admin/config/search/domain_based_search'] = array(
+    'title' => 'Domain Based Search',
+    'description' => 'Configure the domains where domain based searching will be enabled. Domain based search will only show domain related contents in search results',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('pori_search_domain_based_search_settings_form'),
+    'access arguments' => array('administer search_api'),
+    'type' => MENU_NORMAL_ITEM,
+  );
+
+  return $items;
+}
+
+/**
+ * Admin settings form for /admin/config/search/boost for boosting document types in search
+ */
+function pori_search_boost_settings_form($form, &$form_state) {
+  $form['kada_search_feature_boost_types'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Boost factors for different document types'),
+    '#default_value' => variable_get('kada_search_feature_boost_types', ''),
+    '#description' => t('Boost factors for document types, in a format type|50, for example: page|50. One by line.'),
+  );
+
+  return system_settings_form($form);
+}
+
+/**
+ * Admin settings for search.
+ */
+function pori_search_settings_form($form, &$form_state) {
+  $group_options = array();
+  $bundles = og_get_all_group_bundle();
+
+  // Get OG bundles.
+  if (isset($bundles['node'])) {
+    foreach ($bundles['node'] as $type => $title) {
+      $nodes = node_load_multiple(array(), array('type' => $type));
+
+      foreach ($nodes as $node) {
+        $group_options[$node->nid] = $node->title;
+      }
+    }
+  }
+
+  $form['kada_search_feature_exclude_groups'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Exclude organic groups'),
+    '#description' => t('Select the organic group that will be excluded from search results'),
+    '#options' => $group_options,
+    '#default_value' => variable_get('kada_search_feature_exclude_groups', array()),
+  );
+
+  $form['kada_search_feature_alphabetical_sort_types'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Types to sort alphabetically'),
+    '#description' => t('Select the types that will trigger alphabetical sorting, when filtered.'),
+    '#options' => node_type_get_names(),
+    '#default_value' => variable_get('kada_search_feature_alphabetical_sort_types', array()),
+  );
+
+  $form['kada_search_feature_date_sort_types'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Types to sort by date'),
+    '#description' => t('Select the types that will use date sorting, when filtered.'),
+    '#options' => node_type_get_names(),
+    '#default_value' => variable_get('kada_search_feature_date_sort_types', array()),
+  );
+
+  // Build non-drupal content types for timebased sorting.
+  $content_types['proceeding'] = t('Proceeding');
+  $form['kada_search_feature_date_sort_types_nd'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Non-Drupal types to sort by date'),
+    '#description' => t('Select the types that will use date sorting, when filtered.'),
+    '#options' => $content_types,
+    '#default_value' => variable_get('kada_search_feature_date_sort_types_nd', array()),
+  );
+
+  $form['kada_search_feature_sort_event_date_label'] = array(
+    '#type' => 'markup',
+    '#prefix' => '<label>',
+    '#markup' => t('Extra options for events'),
+    '#suffix' => '</label>',
+  );
+
+  $form['kada_search_feature_sort_event_date'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Sort events by date'),
+    '#description' => t('Select to have events ordered most current ones first (Published events with earliest start time come first). This selection overrides any other sort selections on page for events. '),
+    '#default_value' => variable_get('kada_search_feature_sort_event_date', array()),
+  );
+
+  return system_settings_form($form);
+}
+
+/**
+ * Admin settings for configuring domain based search.
+ */
+function pori_search_domain_based_search_settings_form($form, &$form_state) {
+  $domains = domain_domains();
+
+  $domain_options = array();
+
+  foreach ($domains as $domain) {
+    $domain_options[$domain['domain_id']] = $domain['sitename'] . ' (' . $domain['subdomain'] . ')';
+  }
+
+  $form['kada_search_feature_domain_search'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Enable domain based search for the selected domains:'),
+    '#description' => t('Limit the search results of selected domains to domain related content only'),
+    '#options' => $domain_options,
+    '#default_value' => variable_get('kada_search_feature_domain_search', array()),
+  );
+
+  return system_settings_form($form);
+}
+
+/**
+ * Implements hook_search_api_solr_query_alter().
+ *
+ * Alters the query sent to SOLR to add boost query parameters
+ */
+function pori_search_search_api_solr_query_alter(array &$call_args, SearchApiQueryInterface $query) {
+  $alphabetical_types = variable_get('kada_search_feature_alphabetical_sort_types', array());
+  $date_types = variable_get('kada_search_feature_date_sort_types', array());
+  $date_types_nd = variable_get('kada_search_feature_date_sort_types_nd', array());
+  $event_sort = variable_get('kada_search_feature_sort_event_date', array());
+
+  foreach($date_types as $date_type => $key) {
+    if($key !== $date_type) {
+      unset($date_types[$date_type]);
+    }
+  }
+  foreach($date_types_nd as $date_type_nd => $key) {
+    if($key !== $date_type_nd) {
+      unset($date_types_nd[$date_type_nd]);
+    }
+  }
+  foreach($alphabetical_types as $alphabetical_type => $key) {
+    if($key !== $alphabetical_type ) {
+      unset($alphabetical_types[$alphabetical_type]);
+    }
+  }
+
+  foreach ($call_args['params']['fq'] as $fq) {
+    // If a type filter defined for alphabetical sort set, change the sort.
+    if (preg_match('/\(ss_type:"([^"]+)"\)/', $fq, $matches) && in_array($matches[1], $alphabetical_types)) {
+      $call_args['params']['sort'] = array('ss_title_field asc');
+    }
+    // If a type filter defined for date sort set, change the sort.
+    if (preg_match('/\(ss_type:"([^"]+)"\)/', $fq, $matches) && in_array($matches[1], $date_types)) {
+      $call_args['params']['sort'] = 'ds_created desc';
+    }
+    // If a type filter defined for non-drupal date sort set, change the sort.
+    if (preg_match('/\(ss_type:"([^"]+)"\)/', $fq, $matches) && in_array($matches[1], $date_types_nd)) {
+      $call_args['params']['sort'] = 'value_date desc';
+    }
+    // If event and sorted by most current first.
+    if (preg_match('/\(ss_type:"([^"]+)"\)/', $fq, $matches) && in_array($matches[1], array('event')) && $event_sort == 1) {
+      $call_args['params']['sort'] = 'ds_field_event_date$value asc';
+    }
+  }
+  // Boost types defined in /admin/config/search/boost
+  $boost_types = variable_get('kada_search_feature_boost_types', 'page|50');
+  $boost_types = explode("\n", $boost_types);
+  foreach ($boost_types as $boost_type) {
+    $boost_type = explode('|', $boost_type);
+    $call_args['params']['bq'][$boost_type[0]] = "ss_type:\"$boost_type[0]\"^$boost_type[1]";
+  }
+
+  // Filter the excluded sections out only outside the Search API admin;
+  // it should show the unmodified index figures to avoid confusion.
+  if (!(arg(0) == 'admin' && arg(1) == 'config' && arg(2) == 'search' && arg(3) == 'search_api')) {
+    // Filter out excluded groups.
+    $excluded_groups = array_filter(variable_get('kada_search_feature_exclude_groups', array()));
+    foreach ($excluded_groups as $gid) {
+      $call_args['params']['fq'][] = "-im_og_group_ref:$gid OR -is_nid:$gid";
+    }
+  }
+
+  pori_search_add_domain_filter_to_solr_query($call_args);
+}
+
+/**
+ * #4817: Adds a domain filter to Solr query arguments if the current domain is
+ * configured to use domain based search. The domain comparison uses domain
+ * IDs rather than domain machine names, since the machine names can
+ * potentially change.
+ *
+ * @todo Add domain ID to indexes after this feature has been deployed, then
+ * enable the domain based search to specific domains from the configuration.
+ *
+ * @param array $call_args See hook_search_api_solr_query_alter().
+ */
+function pori_search_add_domain_filter_to_solr_query(array &$call_args) {
+  $enabled_domains = array_filter(variable_get('kada_search_feature_domain_search', array()), 'intval');
+  $domain = domain_get_domain();
+  $current_domain_id = $domain['domain_id'];
+  if (in_array($current_domain_id, $enabled_domains)) {
+    $call_args['params']['fq'][] = "im_domain_domain_id:$current_domain_id";
+  }
+}


### PR DESCRIPTION
… some more filter options for search. Using kada prefixed variables to maintain compatibility

drush cc all

1. Set the necessary settings in the three settings forms under admin/config/search
2. Re-index and test the search according to the selected settings.