### PR TITLE
PORI-322: Order phonebook view secondarily by first name

### DIFF
--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.views_default.inc
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.views_default.inc
@@ -182,6 +182,10 @@ function pori_contact_information_feature_views_default_views() {
   $handler->display->display_options['sorts']['field_surname_value']['id'] = 'field_surname_value';
   $handler->display->display_options['sorts']['field_surname_value']['table'] = 'field_data_field_surname';
   $handler->display->display_options['sorts']['field_surname_value']['field'] = 'field_surname_value';
+  /* Sort criterion: Content: First name (field_first_name) */
+  $handler->display->display_options['sorts']['field_first_name_value']['id'] = 'field_first_name_value';
+  $handler->display->display_options['sorts']['field_first_name_value']['table'] = 'field_data_field_first_name';
+  $handler->display->display_options['sorts']['field_first_name_value']['field'] = 'field_first_name_value';
   /* Filter criterion: Content: Published */
   $handler->display->display_options['filters']['status']['id'] = 'status';
   $handler->display->display_options['filters']['status']['table'] = 'node';


### PR DESCRIPTION
drush fra -y

Phonebook search for Mäkelä should be in order by first name.