### PR TITLE
Fix Visitpori front page by changing the related contexts slightly.

### DIFF
--- a/drupal/code/modules/features/pori_configuration/pori_configuration.info
+++ b/drupal/code/modules/features/pori_configuration/pori_configuration.info
@@ -18,6 +18,7 @@ dependencies[] = locale
 dependencies[] = options
 dependencies[] = pori_attraction_feature
 dependencies[] = pori_configuration_overrides_feature
+dependencies[] = pori_section_override_feature
 dependencies[] = pori_widget_feature
 dependencies[] = scald
 dependencies[] = strongarm

--- a/drupal/code/modules/features/pori_configuration/pori_configuration.install
+++ b/drupal/code/modules/features/pori_configuration/pori_configuration.install
@@ -55,3 +55,10 @@ function pori_configuration_update_7106(&$sandbox) {
 function pori_configuration_update_7107(&$sandbox) {
   module_enable(array('bigmenu'));
 }
+
+/*
+ * Enable the Section override feature.
+ */
+function pori_configuration_update_7108(&$sandbox) {
+  module_enable(array('pori_section_override_feature'));
+}

--- a/drupal/code/modules/features/pori_section_override_feature/pori_section_override_feature.features.features_overrides.inc
+++ b/drupal/code/modules/features/pori_section_override_feature/pori_section_override_feature.features.features_overrides.inc
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @file
+ * pori_section_override_feature.features.features_overrides.inc
+ */
+
+/**
+ * Implements hook_features_override_default_overrides().
+ */
+function pori_section_override_feature_features_override_default_overrides() {
+  // This code is only used for UI in features. Exported alters hooks do the magic.
+  $overrides = array();
+
+  // Exported overrides for: context
+  $overrides["context.default_section.conditions|context|values|~visitpori_domain"] = '~visitpori_domain';
+  $overrides["context.section_menus.condition_mode"] = 1;
+  $overrides["context.section_menus.conditions|context_all"] = array(
+    'values' => array(
+      'default_section' => 'default_section',
+    ),
+  );
+
+ return $overrides;
+}

--- a/drupal/code/modules/features/pori_section_override_feature/pori_section_override_feature.features.inc
+++ b/drupal/code/modules/features/pori_section_override_feature/pori_section_override_feature.features.inc
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @file
+ * pori_section_override_feature.features.inc
+ */
+
+/**
+ * Implements hook_context_default_contexts_alter().
+ */
+function pori_section_override_feature_context_default_contexts_alter(&$data) {
+  if (isset($data['default_section'])) {
+    $data['default_section']->conditions['context']['values']['~visitpori_domain'] = '~visitpori_domain'; /* WAS: '' */
+  }
+  if (isset($data['section_menus'])) {
+    $data['section_menus']->condition_mode = 1; /* WAS: 0 */
+    $data['section_menus']->conditions['context_all'] = array(
+      'values' => array(
+        'default_section' => 'default_section',
+      ),
+    ); /* WAS: '' */
+  }
+}

--- a/drupal/code/modules/features/pori_section_override_feature/pori_section_override_feature.info
+++ b/drupal/code/modules/features/pori_section_override_feature/pori_section_override_feature.info
@@ -1,0 +1,14 @@
+name = Pori section override
+core = 7.x
+package = Pori
+version = 7.x-1.0-dev
+dependencies[] = kada_domains_feature
+dependencies[] = kada_sections_feature
+features[features_api][] = api:2
+features[features_override_items][] = context.default_section
+features[features_override_items][] = context.section_header
+features[features_override_items][] = context.section_menus
+features[features_overrides][] = context.default_section.conditions|context|values|~visitpori_domain
+features[features_overrides][] = context.section_menus.condition_mode
+features[features_overrides][] = context.section_menus.conditions|context_all
+features_exclude[features_overrides][context.section_header.conditions|context_all|values|~visitpori_domain] = context.section_header.conditions|context_all|values|~visitpori_domain

--- a/drupal/code/modules/features/pori_section_override_feature/pori_section_override_feature.module
+++ b/drupal/code/modules/features/pori_section_override_feature/pori_section_override_feature.module
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @file
+ * Code for the Pori section override feature.
+ */
+
+include_once 'pori_section_override_feature.features.inc';

--- a/drupal/code/modules/features/visitpori_configurations/visitpori_configurations.context.inc
+++ b/drupal/code/modules/features/visitpori_configurations/visitpori_configurations.context.inc
@@ -148,12 +148,6 @@ function visitpori_configurations_context_default_contexts() {
   $context->description = 'This sitewide context is triggered when using page in English';
   $context->tag = 'section';
   $context->conditions = array(
-    'context' => array(
-      'values' => array(
-        '~section' => '~section',
-        '~section_front' => '~section_front',
-      ),
-    ),
     'context_all' => array(
       'values' => array(
         'visitpori_domain' => 'visitpori_domain',
@@ -197,12 +191,6 @@ function visitpori_configurations_context_default_contexts() {
   $context->description = 'This sitewide context is triggered when using page in Finnish';
   $context->tag = 'section';
   $context->conditions = array(
-    'context' => array(
-      'values' => array(
-        '~section' => '~section',
-        '~section_front' => '~section_front',
-      ),
-    ),
     'context_all' => array(
       'values' => array(
         'visitpori_domain' => 'visitpori_domain',

--- a/drupal/code/modules/features/visitpori_configurations/visitpori_configurations.info
+++ b/drupal/code/modules/features/visitpori_configurations/visitpori_configurations.info
@@ -10,6 +10,7 @@ dependencies[] = features
 dependencies[] = kada_widget_feature
 dependencies[] = menu
 dependencies[] = menu_block
+dependencies[] = pori_configuration
 dependencies[] = pori_contact_information_feature
 dependencies[] = pori_widget_feature
 dependencies[] = strongarm


### PR DESCRIPTION
drush fra -y

Visitpori front page should no longer have the extra header, menu and should have the contact information in the footer.