### PR TITLE
PORI-327 Improved jpg image quality

### DIFF
--- a/drupal/code/modules/features/pori_configuration/pori_configuration.info
+++ b/drupal/code/modules/features/pori_configuration/pori_configuration.info
@@ -92,5 +92,6 @@ features[variable][] = googleanalytics_translation_set
 features[variable][] = googleanalytics_visibility_pages
 features[variable][] = googleanalytics_visibility_roles
 features[variable][] = hotjar_settings
+features[variable][] = image_jpeg_quality
 features[variable_realm][] = domain:pori_fi
 features[vef_video_styles][] = pori_default_style

--- a/drupal/code/modules/features/pori_configuration/pori_configuration.strongarm.inc
+++ b/drupal/code/modules/features/pori_configuration/pori_configuration.strongarm.inc
@@ -499,5 +499,12 @@ user/*/*',
   );
   $export['hotjar_settings'] = $strongarm;
 
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'image_jpeg_quality';
+  $strongarm->value = '95';
+  $export['image_jpeg_quality'] = $strongarm;
+
   return $export;
 }


### PR DESCRIPTION
To test:

1. drush image-flush
2. drush cc all
3. Make sure images such as the front page green bear image doesn't have anymore visible jpeg artifacts.

NOTICE: This image-flush needs to be run on the testing and production as well if we want to have these changes effecting the already added images.