### PR TITLE
PORI-336 Added rss link to front page

### DIFF
--- a/drupal/code/modules/features/pori_front_page_liftups/pori_front_page_liftups.features.features_overrides.inc
+++ b/drupal/code/modules/features/pori_front_page_liftups/pori_front_page_liftups.features.features_overrides.inc
@@ -17,6 +17,12 @@ function pori_front_page_liftups_features_override_default_overrides() {
       '~visitpori_domain' => '~visitpori_domain',
     ),
   );
+  $overrides["context.front_page.reactions|block|blocks|kada_export_feature-kada_rss_feed_for_news_archive"] = array(
+    'module' => 'kada_export_feature',
+    'delta' => 'kada_rss_feed_for_news_archive',
+    'region' => 'before_content',
+    'weight' => -9,
+  );
   $overrides["context.front_page.reactions|block|blocks|quicktabs-feed_tabs_frontpage_promoted_con"] = array(
     'module' => 'quicktabs',
     'delta' => 'feed_tabs_frontpage_promoted_con',

--- a/drupal/code/modules/features/pori_front_page_liftups/pori_front_page_liftups.features.inc
+++ b/drupal/code/modules/features/pori_front_page_liftups/pori_front_page_liftups.features.inc
@@ -30,6 +30,12 @@ function pori_front_page_liftups_context_default_contexts_alter(&$data) {
         '~visitpori_domain' => '~visitpori_domain',
       ),
     ); /* WAS: '' */
+    $data['front_page']->reactions['block']['blocks']['kada_export_feature-kada_rss_feed_for_news_archive'] = array(
+      'module' => 'kada_export_feature',
+      'delta' => 'kada_rss_feed_for_news_archive',
+      'region' => 'before_content',
+      'weight' => -9,
+    ); /* WAS: '' */
     $data['front_page']->reactions['block']['blocks']['quicktabs-feed_tabs_frontpage_promoted_con'] = array(
       'module' => 'quicktabs',
       'delta' => 'feed_tabs_frontpage_promoted_con',

--- a/drupal/code/modules/features/pori_front_page_liftups/pori_front_page_liftups.info
+++ b/drupal/code/modules/features/pori_front_page_liftups/pori_front_page_liftups.info
@@ -14,6 +14,7 @@ features[features_api][] = api:2
 features[features_override_items][] = context.front_page
 features[features_override_items][] = quicktabs.feed_tabs
 features[features_override_items][] = views_view.kada_news
+features[features_overrides][] = context.front_page.reactions|block|blocks|kada_export_feature-kada_rss_feed_for_news_archive
 features[features_overrides][] = context.front_page.reactions|block|blocks|quicktabs-feed_tabs_frontpage_promoted_con
 features[features_overrides][] = context.front_page.reactions|block|blocks|views-kada_news-block_1
 features[features_overrides][] = context.front_page.reactions|block|blocks|views-kada_news-front_block


### PR DESCRIPTION
To test:

1. drush fra -y && drush cc all
2. Go to front page and make sure there is a link under the feed block that links to rss feed that has news archive feed.