### PR TITLE
PORI-247 Disabled ajax from phone-book

### DIFF
--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.views_default.inc
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.views_default.inc
@@ -24,7 +24,6 @@ function pori_contact_information_feature_views_default_views() {
   $handler = $view->new_display('default', 'Master', 'default');
   $handler->display->display_options['title'] = 'Phone book';
   $handler->display->display_options['css_class'] = 'person-card-list';
-  $handler->display->display_options['use_ajax'] = TRUE;
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'perm';
   $handler->display->display_options['cache']['type'] = 'none';


### PR DESCRIPTION
To test:

1. drush fra -y && drush cc all
2. Go to https://local.pori.fi/phone-book and make sure ajax is not used and keywords used in the search are visible in the url.