### PR TITLE
PORI-343: Fix a few notices in contact import

### DIFF
--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.module
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.module
@@ -20,16 +20,18 @@ function pori_contact_information_feature_feeds_presave($source, $entity, $item,
     // Replace comma followed by a post code with newline and the post code.
     // Newlines don't work in Feeds Tamper.
     foreach ($entity->field_visiting_address as $lang => &$addr_item) {
-      $addr_item[0]['value'] = preg_replace('/,\W*([0-9]{5})/', "\n\\1", $addr_item[0]['value']);
+      if (isset($addr_item[0]['value'])) {
+        $addr_item[0]['value'] = preg_replace('/,\W*([0-9]{5})/', "\n\\1", $addr_item[0]['value']);
+      }
     }
 
-    // Prevent publishing of the mobile phone number.
-    if (!empty($item[13])) {
-      $entity->field_mobile_phone_work = array();
-    }
     // Prevent publishing of the phone number.
     if (!empty($item[12])) {
       $entity->field_phone = array();
+    }
+    // Prevent publishing of the mobile phone number.
+    if (!empty($item[13])) {
+      $entity->field_mobile_phone_work = array();
     }
   }
 }

--- a/drupal/conf/kadaproject.make
+++ b/drupal/conf/kadaproject.make
@@ -266,6 +266,7 @@ projects[entityqueue][patch][] = "../patches/entityqueue_subqueue_export.patch"
 
 projects[entity_action_log][version] = 1.0-beta2
 projects[entity_action_log][subdir] = contrib
+projects[entity_action_log][patch][] = "https://www.drupal.org/files/issues/2018-03-23/2955606-2_fix_notice.patch"
 
 ; Only dev version is available for entity_base_type module.
 projects[entity_base_type][type] = module


### PR DESCRIPTION
./build.sh update

1. Re-run the contact information import via cron:
`drush @pori.docker elysia-cron run pori_contact_information_feature_cron --ignore-time --ignore-running`
2. Check that the cron run has caused no notices to the terminal output.