### PR TITLE
PORI-X Removed English as an option from the Visitpori domain languag…

### DIFF
--- a/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.module
+++ b/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.module
@@ -5,3 +5,13 @@
  */
 
 include_once 'pori_visitpori_override_feature.features.inc';
+
+function pori_visitpori_override_feature_language_switch_links_alter(&$result, $type, $path) {
+  $current_domain = domain_get_domain();
+  $en_forbidden_domains = array('visitpori_fi');
+
+  // Remove English if the current domain is in the forbidden list
+  if (in_array($current_domain['machine_name'], $en_forbidden_domains)) {
+    unset($result['en']);
+  }
+}


### PR DESCRIPTION
…e switcher

To test:

1. drush cc all
2. Make sure on local.visitpori.fi you are not able to choose English from language switcher