### PR TITLE
PORI-370 Removed duplicate title from section nodes

### DIFF
--- a/drupal/code/themes/custom/kada/layouts/kada-default/kada-default-layout.tpl.php
+++ b/drupal/code/themes/custom/kada/layouts/kada-default/kada-default-layout.tpl.php
@@ -118,7 +118,7 @@
           <div class="content__wrapper content-wrapper">
         <?php endif; ?>
 
-        <?php if ($title && !$is_front): ?>
+        <?php if ($title && !$is_front && !$node->type == 'section'): ?>
           <?php print render($title_prefix); ?>
             <header class="content__header content-header">
                 <h1 class="content-header__title"><?php print $title; ?></h1>


### PR DESCRIPTION
To test:

1. drush cc all
2. Create a section page if not already available and make sure on the section page the section title is visible only in the header and not on the content area.