### PR TITLE
PORI-348: Change search to use relevance order instead of create date

### DIFF
--- a/drupal/code/modules/features/pori_search/pori_search.views_default.inc
+++ b/drupal/code/modules/features/pori_search/pori_search.views_default.inc
@@ -136,11 +136,11 @@ function pori_search_views_default_views() {
   $handler->display->display_options['fields']['field_theme']['display'] = 'view';
   $handler->display->display_options['fields']['field_theme']['view_mode'] = 'token';
   $handler->display->display_options['fields']['field_theme']['bypass_access'] = 0;
-  /* Sort criterion: Indexed Node: Date created */
-  $handler->display->display_options['sorts']['created']['id'] = 'created';
-  $handler->display->display_options['sorts']['created']['table'] = 'search_api_index_pori_search_index';
-  $handler->display->display_options['sorts']['created']['field'] = 'created';
-  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+  /* Sort criterion: Search: Relevance */
+  $handler->display->display_options['sorts']['search_api_relevance']['id'] = 'search_api_relevance';
+  $handler->display->display_options['sorts']['search_api_relevance']['table'] = 'search_api_index_pori_search_index';
+  $handler->display->display_options['sorts']['search_api_relevance']['field'] = 'search_api_relevance';
+  $handler->display->display_options['sorts']['search_api_relevance']['order'] = 'DESC';
   /* Filter criterion: Search: Fulltext search */
   $handler->display->display_options['filters']['search_api_views_fulltext']['id'] = 'search_api_views_fulltext';
   $handler->display->display_options['filters']['search_api_views_fulltext']['table'] = 'search_api_index_pori_search_index';


### PR DESCRIPTION
drush fra -y

The search results should no longer be ordered by creation date but relevance to the keyword.