### PR TITLE
PORI-393: Add indexing for field_file_attachment

### DIFF
--- a/drupal/code/modules/features/pori_search/pori_search.features.inc
+++ b/drupal/code/modules/features/pori_search/pori_search.features.inc
@@ -55,6 +55,7 @@ function pori_search_default_search_api_index() {
         "domain_domain_id" : { "type" : "list\\u003Cinteger\\u003E" },
         "field_additional_info_link:title" : { "type" : "list\\u003Ctext\\u003E" },
         "field_alternative_name" : { "type" : "list\\u003Ctext\\u003E" },
+        "field_file_attachment" : { "type" : "list\\u003Cinteger\\u003E", "entity_type" : "scald_atom" },
         "field_keywords" : { "type" : "list\\u003Cinteger\\u003E", "entity_type" : "taxonomy_term" },
         "field_lead_paragraph" : { "type" : "text" },
         "field_lead_paragraph_et" : { "type" : "text" },


### PR DESCRIPTION
drush fra -y

1. Re-index the search index.
2. Search for example for ”pdf” and check that the results include content that doesn't have the string ”pdf”  in the text body/title, but does in the attachment field.