### PR TITLE
PORI-367 Added code that changes language switcher to point to front …

### DIFF
--- a/drupal/code/modules/features/pori_configuration/pori_configuration.module
+++ b/drupal/code/modules/features/pori_configuration/pori_configuration.module
@@ -5,3 +5,19 @@
  */
 
 include_once 'pori_configuration.features.inc';
+
+/**
+ * Implements hook_language_switch_links_alter().
+ */
+function pori_configuration_language_switch_links_alter(&$links, $type, $path) {
+  global $language;
+  $current_domain = domain_get_domain();
+  // Change language switcher behavior so that it links always to front page.
+  if ($type == LANGUAGE_TYPE_INTERFACE && isset($links[$language->language]) && $current_domain['machine_name'] == 'pori_fi') {
+    foreach ($links as $langcode => &$link) {
+      if ($link['language']->language != $language->language ) {
+        $link['href'] = '<front>';
+      }
+    }
+  }
+}

--- a/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.module
+++ b/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.module
@@ -6,6 +6,9 @@
 
 include_once 'pori_visitpori_override_feature.features.inc';
 
+/**
+ * Implements hook_language_switch_links_alter().
+ */
 function pori_visitpori_override_feature_language_switch_links_alter(&$result, $type, $path) {
   $current_domain = domain_get_domain();
   $first_path_argument = arg(0);


### PR DESCRIPTION
…page when in pori.fi domain

To test:

1. drush cc all
2. Go to some subpage on local.pori.fi and change language to English. Make sure you are redirected to front page.
3. Go to local.visitpori.fi and go to some attraction card and change language to English or any other language in the list. Make sure you are not redirected to front page.