### PR TITLE
PORI-X: Show English language link in VisitPori

### DIFF
--- a/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.module
+++ b/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.module
@@ -13,7 +13,7 @@ function pori_visitpori_override_feature_language_switch_links_alter(&$result, $
   $current_domain = domain_get_domain();
   $first_path_argument = arg(0);
   $excluded_domains = array(
-    'en' => array('visitpori_fi'),
+    'en' => array(),
     'de' => array('pori_fi', 'visitpori_fi'),
     'sv' => array('pori_fi', 'visitpori_fi'),
   );


### PR DESCRIPTION
drush cc all

1. VisitPori pages should all have English in the language selection menu.