### PR TITLE
PORI-428: Show German in Visitpori language menu

### DIFF
--- a/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.module
+++ b/drupal/code/modules/features/pori_visitpori_override_feature/pori_visitpori_override_feature.module
@@ -14,7 +14,7 @@ function pori_visitpori_override_feature_language_switch_links_alter(&$result, $
   $first_path_argument = arg(0);
   $excluded_domains = array(
     'en' => array(),
-    'de' => array('pori_fi', 'visitpori_fi'),
+    'de' => array('pori_fi'),
     'sv' => array('pori_fi', 'visitpori_fi'),
   );
 


### PR DESCRIPTION
1. Go to Visitpori and check that it has German in the language menu.