### PR TITLE
PORI-253: Add units to phone book and persons

### DIFF
--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.ds.inc
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.ds.inc
@@ -17,6 +17,11 @@ function pori_contact_information_feature_ds_field_settings_info() {
   $ds_fieldsetting->bundle = 'person';
   $ds_fieldsetting->view_mode = 'person_card';
   $ds_fieldsetting->settings = array(
+    'person_organisation' => array(
+      'weight' => '3',
+      'label' => 'hidden',
+      'format' => 'default',
+    ),
     'person_full_name' => array(
       'weight' => '1',
       'label' => 'hidden',
@@ -24,6 +29,27 @@ function pori_contact_information_feature_ds_field_settings_info() {
     ),
   );
   $export['node|person|person_card'] = $ds_fieldsetting;
+
+  return $export;
+}
+
+/**
+ * Implements hook_ds_custom_fields_info().
+ */
+function pori_contact_information_feature_ds_custom_fields_info() {
+  $export = array();
+
+  $ds_field = new stdClass();
+  $ds_field->api_version = 1;
+  $ds_field->field = 'person_organisation';
+  $ds_field->label = 'Person organisation';
+  $ds_field->field_type = 3;
+  $ds_field->entities = array(
+    'node' => 'node',
+  );
+  $ds_field->ui_limit = 'person|*';
+  $ds_field->properties = array();
+  $export['person_organisation'] = $ds_field;
 
   return $export;
 }
@@ -47,21 +73,23 @@ function pori_contact_information_feature_ds_layout_settings_info() {
         0 => 'field_person_image',
         1 => 'person_full_name',
         2 => 'field_employee_title',
-        3 => 'field_profession',
-        4 => 'field_office_tr',
-        5 => 'field_visiting_address',
-        6 => 'field_email_single',
-        7 => 'field_mobile_phone',
-        8 => 'field_phone',
-        9 => 'field_mobile_phone_work',
-        10 => 'field_phone_switch',
-        11 => 'field_fax_number',
+        3 => 'person_organisation',
+        4 => 'field_profession',
+        5 => 'field_office_tr',
+        6 => 'field_visiting_address',
+        7 => 'field_email_single',
+        8 => 'field_mobile_phone',
+        9 => 'field_phone',
+        10 => 'field_mobile_phone_work',
+        11 => 'field_phone_switch',
+        12 => 'field_fax_number',
       ),
     ),
     'fields' => array(
       'field_person_image' => 'main_content',
       'person_full_name' => 'main_content',
       'field_employee_title' => 'main_content',
+      'person_organisation' => 'main_content',
       'field_profession' => 'main_content',
       'field_office_tr' => 'main_content',
       'field_visiting_address' => 'main_content',

--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.ds.inc
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.ds.inc
@@ -17,8 +17,13 @@ function pori_contact_information_feature_ds_field_settings_info() {
   $ds_fieldsetting->bundle = 'person';
   $ds_fieldsetting->view_mode = 'person_card';
   $ds_fieldsetting->settings = array(
+    'person_availability' => array(
+      'weight' => '13',
+      'label' => 'hidden',
+      'format' => 'default',
+    ),
     'person_organisation' => array(
-      'weight' => '3',
+      'weight' => '4',
       'label' => 'hidden',
       'format' => 'default',
     ),
@@ -38,6 +43,18 @@ function pori_contact_information_feature_ds_field_settings_info() {
  */
 function pori_contact_information_feature_ds_custom_fields_info() {
   $export = array();
+
+  $ds_field = new stdClass();
+  $ds_field->api_version = 1;
+  $ds_field->field = 'person_availability';
+  $ds_field->label = 'Person availability';
+  $ds_field->field_type = 3;
+  $ds_field->entities = array(
+    'node' => 'node',
+  );
+  $ds_field->ui_limit = 'person|*';
+  $ds_field->properties = array();
+  $export['person_availability'] = $ds_field;
 
   $ds_field = new stdClass();
   $ds_field->api_version = 1;
@@ -73,8 +90,8 @@ function pori_contact_information_feature_ds_layout_settings_info() {
         0 => 'field_person_image',
         1 => 'person_full_name',
         2 => 'field_employee_title',
-        3 => 'person_organisation',
-        4 => 'field_profession',
+        3 => 'field_profession',
+        4 => 'person_organisation',
         5 => 'field_office_tr',
         6 => 'field_visiting_address',
         7 => 'field_email_single',
@@ -83,14 +100,15 @@ function pori_contact_information_feature_ds_layout_settings_info() {
         10 => 'field_mobile_phone_work',
         11 => 'field_phone_switch',
         12 => 'field_fax_number',
+        13 => 'person_availability',
       ),
     ),
     'fields' => array(
       'field_person_image' => 'main_content',
       'person_full_name' => 'main_content',
       'field_employee_title' => 'main_content',
-      'person_organisation' => 'main_content',
       'field_profession' => 'main_content',
+      'person_organisation' => 'main_content',
       'field_office_tr' => 'main_content',
       'field_visiting_address' => 'main_content',
       'field_email_single' => 'main_content',
@@ -99,6 +117,7 @@ function pori_contact_information_feature_ds_layout_settings_info() {
       'field_mobile_phone_work' => 'main_content',
       'field_phone_switch' => 'main_content',
       'field_fax_number' => 'main_content',
+      'person_availability' => 'main_content',
     ),
     'classes' => array(),
     'wrappers' => array(

--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.feeds_importer_default.inc
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.feeds_importer_default.inc
@@ -144,6 +144,13 @@ function pori_contact_information_feature_feeds_importer_default() {
             'source' => 'Location',
             'target' => 'field_activity_unit',
             'unique' => FALSE,
+            'language' => 'und',
+          ),
+          17 => array(
+            'source' => 'Puhelin-aukioloaika',
+            'target' => 'field_availability',
+            'unique' => FALSE,
+            'language' => 'und',
           ),
         ),
         'update_existing' => '2',

--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.feeds_importer_default.inc
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.feeds_importer_default.inc
@@ -33,8 +33,8 @@ function pori_contact_information_feature_feeds_importer_default() {
       'plugin_key' => 'FeedsCSVParser',
       'config' => array(
         'delimiter' => ';',
-        'no_headers' => 1,
-        'encoding' => 'UTF-8',
+        'no_headers' => 0,
+        'encoding' => 'ISO-8859-15',
       ),
     ),
     'processor' => array(
@@ -125,6 +125,24 @@ function pori_contact_information_feature_feeds_importer_default() {
           13 => array(
             'source' => 'Company Contact',
             'target' => 'field_person_type',
+            'unique' => FALSE,
+            'language' => 'und',
+          ),
+          14 => array(
+            'source' => 'Hallintokunta',
+            'target' => 'field_branch',
+            'unique' => FALSE,
+            'language' => 'und',
+          ),
+          15 => array(
+            'source' => 'Department',
+            'target' => 'field_unit',
+            'unique' => FALSE,
+            'language' => 'und',
+          ),
+          16 => array(
+            'source' => 'Location',
+            'target' => 'field_activity_unit',
             'unique' => FALSE,
           ),
         ),

--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.info
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.info
@@ -24,6 +24,7 @@ features[ctools][] = feeds:feeds_importer_default:1
 features[ctools][] = feeds_tamper:feeds_tamper_default:2
 features[ctools][] = views:views_default:3.0
 features[ds_field_settings][] = node|person|person_card
+features[ds_fields][] = person_organisation
 features[ds_layout_settings][] = node|person|person_card
 features[ds_view_modes][] = person_card
 features[features_api][] = api:2

--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.info
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.info
@@ -24,6 +24,7 @@ features[ctools][] = feeds:feeds_importer_default:1
 features[ctools][] = feeds_tamper:feeds_tamper_default:2
 features[ctools][] = views:views_default:3.0
 features[ds_field_settings][] = node|person|person_card
+features[ds_fields][] = person_availability
 features[ds_fields][] = person_organisation
 features[ds_layout_settings][] = node|person|person_card
 features[ds_view_modes][] = person_card

--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.module
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.module
@@ -64,3 +64,20 @@ function pori_contact_information_feature_cron() {
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_node().
+ */
+function pori_contact_information_feature_preprocess_node(&$vars) {
+  $node = $vars['node'];
+  if (isset($node->field_branch) && isset($node->field_unit)) {
+    $parts = array();
+    if (!empty($node->field_branch)) {
+      $parts[] = reset($node->field_branch['und'])['value'];
+    }
+    if (!empty($node->field_unit)) {
+      $parts[] = reset($node->field_unit['und'])['value'];
+    }
+    $vars['person_organisation'] = implode(' | ', $parts);
+  }
+}

--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.module
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.module
@@ -30,7 +30,7 @@ function pori_contact_information_feature_feeds_presave($source, $entity, $item,
  */
 function pori_contact_information_feature_cron() {
   $importers = array(
-    'phone_csv' => 'private://transfer/PORIKAexport2.csv',
+    'phone_csv' => 'private://transfer/Directory_Entries_26841_295309_.csv',
   );
   watchdog('pori_contact_information', 'Running contact information feed importers...');
 

--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.module
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.module
@@ -80,4 +80,7 @@ function pori_contact_information_feature_preprocess_node(&$vars) {
     }
     $vars['person_organisation'] = implode(' | ', $parts);
   }
+  if (!empty($node->field_availability)) {
+    $vars['person_availability'] = t('Available') . ' ' . lcfirst(reset($node->field_availability['und'])['value']) . '.';
+  }
 }

--- a/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.views_default.inc
+++ b/drupal/code/modules/features/pori_contact_information_feature/pori_contact_information_feature.views_default.inc
@@ -99,6 +99,13 @@ function pori_contact_information_feature_views_default_views() {
   $handler->display->display_options['header']['area_text_custom']['field'] = 'area_text_custom';
   $handler->display->display_options['header']['area_text_custom']['content'] = 'Telephone exchange of the City of Pori: <a href="tel:(02) 621 1100">(02) 621 1100</a><br>
 <a href="mailto:kirjaamo@pori.fi">kirjaamo@pori.fi</a>';
+  /* Field: Content: Unit */
+  $handler->display->display_options['fields']['field_unit']['id'] = 'field_unit';
+  $handler->display->display_options['fields']['field_unit']['table'] = 'field_data_field_unit';
+  $handler->display->display_options['fields']['field_unit']['field'] = 'field_unit';
+  $handler->display->display_options['fields']['field_unit']['label'] = '';
+  $handler->display->display_options['fields']['field_unit']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['field_unit']['element_label_colon'] = FALSE;
   /* Field: Content: First name */
   $handler->display->display_options['fields']['field_first_name']['id'] = 'field_first_name';
   $handler->display->display_options['fields']['field_first_name']['table'] = 'field_data_field_first_name';
@@ -120,6 +127,13 @@ function pori_contact_information_feature_views_default_views() {
   $handler->display->display_options['fields']['field_employee_title']['label'] = '';
   $handler->display->display_options['fields']['field_employee_title']['exclude'] = TRUE;
   $handler->display->display_options['fields']['field_employee_title']['element_label_colon'] = FALSE;
+  /* Field: Content: Branch */
+  $handler->display->display_options['fields']['field_branch']['id'] = 'field_branch';
+  $handler->display->display_options['fields']['field_branch']['table'] = 'field_data_field_branch';
+  $handler->display->display_options['fields']['field_branch']['field'] = 'field_branch';
+  $handler->display->display_options['fields']['field_branch']['label'] = '';
+  $handler->display->display_options['fields']['field_branch']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['field_branch']['element_label_colon'] = FALSE;
   /* Field: Content: Email */
   $handler->display->display_options['fields']['field_email_single']['id'] = 'field_email_single';
   $handler->display->display_options['fields']['field_email_single']['table'] = 'field_data_field_email_single';
@@ -227,16 +241,18 @@ function pori_contact_information_feature_views_default_views() {
     6 => 0,
   );
   $handler->display->display_options['filters']['combine']['fields'] = array(
+    'field_unit' => 'field_unit',
     'field_first_name' => 'field_first_name',
     'field_surname' => 'field_surname',
-    'field_fax_number' => 'field_fax_number',
+    'field_employee_title' => 'field_employee_title',
+    'field_branch' => 'field_branch',
+    'field_email_single' => 'field_email_single',
+    'field_visiting_address' => 'field_visiting_address',
+    'field_phone' => 'field_phone',
     'field_mobile_phone' => 'field_mobile_phone',
     'field_mobile_phone_work' => 'field_mobile_phone_work',
-    'field_phone' => 'field_phone',
     'field_phone_switch' => 'field_phone_switch',
-    'field_employee_title' => 'field_employee_title',
-    'field_visiting_address' => 'field_visiting_address',
-    'field_email_single' => 'field_email_single',
+    'field_fax_number' => 'field_fax_number',
   );
 
   /* Display: Page */


### PR DESCRIPTION
drush fra -y; drush cc all

1. Make a new phonebook import through /import
2. Check that the phone book searches for units (and branches, when the data has them) and that both are searchable through the fulltext search.