### PR TITLE
PORI-391: Select the VisitPori section by default for users only havi…

### DIFF
--- a/drupal/code/modules/features/pori_configuration/pori_configuration.module
+++ b/drupal/code/modules/features/pori_configuration/pori_configuration.module
@@ -52,7 +52,7 @@ function pori_configuration_form_views_exposed_form_alter(&$form, &$form_state, 
  */
 function pori_configuration_form_alter(&$form, &$form_state, $form_id) {
   // Only react to node forms with an empty Group audience field.
-  if ($form['#node_edit_form'] && !empty($form['og_group_ref']) && empty($form['og_group_ref'][LANGUAGE_NONE][0]['default']['#default_value'])) {
+  if (isset($form['#node_edit_form']) && $form['#node_edit_form'] && !empty($form['og_group_ref']) && empty($form['og_group_ref'][LANGUAGE_NONE][0]['default']['#default_value'])) {
     global $user, $language;
 
     // If the user only has one domain defined, we could use that as a default.

--- a/drupal/code/modules/features/pori_configuration/pori_configuration.module
+++ b/drupal/code/modules/features/pori_configuration/pori_configuration.module
@@ -43,3 +43,36 @@ function pori_configuration_form_views_exposed_form_alter(&$form, &$form_state, 
     }
   }
 }
+
+/**
+ * Implements hook_form_alter().
+ *
+ * If the user only has one domain set, default to the corresponding section in
+ * node form.
+ */
+function pori_configuration_form_alter(&$form, &$form_state, $form_id) {
+  // Only react to node forms with an empty Group audience field.
+  if ($form['#node_edit_form'] && !empty($form['og_group_ref']) && empty($form['og_group_ref'][LANGUAGE_NONE][0]['default']['#default_value'])) {
+    global $user, $language;
+
+    // If the user only has one domain defined, we could use that as a default.
+    if (count($user->domain_user) == 1) {
+      // Domain to section tnid mapping.
+      $domain_sections = array(
+        'visitpori_fi' => 3183,
+      );
+
+      $domain_machine_name = domain_load_machine_name(reset($user->domain_user));
+      // Check if there's a tnid mapping for the user's sole domain.
+      if (!empty($tnid = $domain_sections[$domain_machine_name])) {
+        $visitpori_sections = translation_node_get_translations($tnid);
+        // ... and if there is, fetch the current language node of the section.
+        if (!empty($sec_id = $visitpori_sections[$language->language])) {
+          $sec_id = $sec_id->nid;
+          // Set as default.
+          $form['og_group_ref'][LANGUAGE_NONE][0]['default']['#default_value'][$sec_id] = $sec_id;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
…ng that domain defined.

drush cc all

1. Log in with a user that only has Visit Pori as an assigned domain.
2. Go to node forms of content types that have the section selection.
3. Check that the section selection already has the correct language version of the VisitPori section selected.