### PR TITLE
PORI-431: Fix the default domain ID to Pori.fi and check that we have…

### DIFF
--- a/drupal/code/modules/features/kada_domains_feature/kada_domains_feature.module
+++ b/drupal/code/modules/features/kada_domains_feature/kada_domains_feature.module
@@ -85,9 +85,10 @@ function kada_domains_feature_init() {
     // a different domain assigned, or it's not a section itself.
     // Gather variables for domain evaluations.
     global $_domain;
-    $default_domain = domain_lookup(1);
-    // Redirect happens only when user is not already in default domain.
-    if (!$_domain['is_default']) {
+    $default_domain = domain_lookup(5);
+    // Redirect happens only when user is not already in default domain and if
+    // we found the default domain.
+    if (!$_domain['is_default'] && $default_domain != -1) {
       $domain = 'http://' . rtrim($default_domain['subdomain'], '/');
       drupal_goto(url(drupal_get_path_alias(), array('absolute' => TRUE, 'base_url' => $domain)), array(), 301);
     }


### PR DESCRIPTION
… a domain to redirect to

drush cc all

1. Remove the section from a news item shown in VisitPori front page.
2. Check that clicking the news item doesn't redirect you to a broken URL. Redirecting to Pori.fi (which might not show the news item) is fine.