### PR TITLE
PORI-443: Changed the kada_news item limit to the same than in kada_n…

### DIFF
--- a/drupal/code/modules/features/pori_liftups/pori_liftups.features.features_overrides.inc
+++ b/drupal/code/modules/features/pori_liftups/pori_liftups.features.features_overrides.inc
@@ -38,6 +38,7 @@ function pori_liftups_features_override_default_overrides() {
 
   // Exported overrides for: views_view
   $overrides["views_view.kada_current.display|default|display_options|css_class"] = 'liftup-box-list liftup-box-list--current';
+  $overrides["views_view.kada_current.display|default|display_options|pager|options|items_per_page"] = 8;
   $overrides["views_view.kada_current_promoted_.display|default|display_options|css_class"] = 'liftup-box-list liftup-box-list--current';
   $overrides["views_view.kada_current_promoted_.display|default|display_options|pager|options|items_per_page"] = 8;
   $overrides["views_view.kada_current_promoted_.display|tab_blogs|display_options|pager|options|items_per_page"] = 8;

--- a/drupal/code/modules/features/pori_liftups/pori_liftups.features.inc
+++ b/drupal/code/modules/features/pori_liftups/pori_liftups.features.inc
@@ -71,6 +71,7 @@ function pori_liftups_ds_layout_settings_info_alter(&$data) {
 function pori_liftups_views_default_views_alter(&$data) {
   if (isset($data['kada_current'])) {
     $data['kada_current']->display['default']->display_options['css_class'] = 'liftup-box-list liftup-box-list--current'; /* WAS: 'liftup-box-list' */
+    $data['kada_current']->display['default']->display_options['pager']['options']['items_per_page'] = 8; /* WAS: 12 */
   }
   if (isset($data['kada_current_promoted_'])) {
     $data['kada_current_promoted_']->display['default']->display_options['css_class'] = 'liftup-box-list liftup-box-list--current'; /* WAS: 'liftup-box-list' */

--- a/drupal/code/modules/features/pori_liftups/pori_liftups.info
+++ b/drupal/code/modules/features/pori_liftups/pori_liftups.info
@@ -47,6 +47,7 @@ features[features_overrides][] = ds_layout_settings.node|liftup|project.settings
 features[features_overrides][] = ds_layout_settings.node|liftup|project.settings|regions|right|3
 features[features_overrides][] = ds_layout_settings.node|liftup|project.settings|regions|right|4
 features[features_overrides][] = views_view.kada_current.display|default|display_options|css_class
+features[features_overrides][] = views_view.kada_current.display|default|display_options|pager|options|items_per_page
 features[features_overrides][] = views_view.kada_current_promoted_.display|default|display_options|css_class
 features[features_overrides][] = views_view.kada_current_promoted_.display|default|display_options|pager|options|items_per_page
 features[features_overrides][] = views_view.kada_current_promoted_.display|tab_blogs|display_options|pager|options|items_per_page


### PR DESCRIPTION
…ews_promoted

drush cc all; drush fra -y

1. Check that both target group pages (/vammaiset) and theme pages (/tyo-ja-yrittaminen) have only eight news items instead of the previous 12.