### PR TITLE
PORI-179: clickable news item image URL

### DIFF
--- a/drupal/code/themes/custom/kada/preprocess/node.preprocess.inc
+++ b/drupal/code/themes/custom/kada/preprocess/node.preprocess.inc
@@ -28,6 +28,12 @@ function kada_preprocess_node(&$variables) {
     $variables['theme_hook_suggestions'][] = 'node__' . $variables['node']->type . '__' . $variables['view_mode'];
   }
 
+  // Target specifically news item 'current' view modes and set the node URL
+  // manually.
+  if ($variables['node']->type == 'news_item' && $variables['view_mode'] == 'current') {
+    $variables['liftup_link_url'] = $variables['node_url'];
+  }
+
   // Linking content image to the give URL if it has been set
   if ($variables['view_mode'] == 'current' || $variables['node']->type == 'liftup' && $variables['view_mode'] == 'teaser') {
     // Optional Link to content URL can be given to a liftup


### PR DESCRIPTION
## What and why

Template for the news feed items already expects a variable containing the URL of the article. However by default this vairable is populated from some specific field that news items does not have. So we manually set this variable to the node URL.

## Testing

Navigate to https://pori.dev.wunder.io/ and verify that news feed item images can be clicked and send you to the appropriate article.

![2019-01-16_14-15-10](https://user-images.githubusercontent.com/1763464/51248560-2a302600-1999-11e9-8dd7-4f7bd496c605.png)
