### PR TITLE
PORI-450 - Makefile changes to fix edit cancel functionality

### DIFF
--- a/drupal/conf/kadaproject.make
+++ b/drupal/conf/kadaproject.make
@@ -171,6 +171,8 @@ projects[conditional_fields][subdir] = contrib
 
 projects[content_lock][version] = 3.0-beta1
 projects[content_lock][subdir] = contrib
+; Patch to fix cancel button problem.
+projects[content_lock][patch][] = https://www.drupal.org/files/issues/cancel-edit-fix-2852631.patch
 
 projects[content_taxonomy][version] = 1.0-rc1
 projects[content_taxonomy][subdir] = contrib


### PR DESCRIPTION
Fixed with patch https://www.drupal.org/project/content_lock/issues/2852631 to enable cancel functionality.