### PR TITLE
PORI: Remove global page title to enable domain-based overrides.

### DIFF
--- a/drupal/code/modules/features/kada_configuration_feature/kada_configuration_feature.features.metatag.inc
+++ b/drupal/code/modules/features/kada_configuration_feature/kada_configuration_feature.features.metatag.inc
@@ -17,16 +17,124 @@ function kada_configuration_feature_metatag_export_default() {
     'disabled' => FALSE,
     'config' => array(
       'title' => array(
-        'value' => '[current-page:title] | [site:name]',
+        'value' => '',
+      ),
+      'description' => array(
+        'value' => '',
+      ),
+      'abstract' => array(
+        'value' => '',
+      ),
+      'keywords' => array(
+        'value' => '',
+      ),
+      'robots' => array(
+        'value' => array(
+          'index' => 0,
+          'follow' => 0,
+          'noindex' => 0,
+          'nofollow' => 0,
+          'noarchive' => 0,
+          'nosnippet' => 0,
+          'noodp' => 0,
+          'noydir' => 0,
+          'noimageindex' => 0,
+          'notranslate' => 0,
+        ),
+      ),
+      'news_keywords' => array(
+        'value' => '',
+      ),
+      'standout' => array(
+        'value' => '',
+      ),
+      'rating' => array(
+        'value' => '',
+      ),
+      'referrer' => array(
+        'value' => '',
       ),
       'generator' => array(
         'value' => 'Drupal 7 (http://drupal.org)',
       ),
+      'rights' => array(
+        'value' => '',
+      ),
+      'image_src' => array(
+        'value' => '',
+      ),
       'canonical' => array(
         'value' => '[current-page:url:absolute]',
       ),
+      'set_cookie' => array(
+        'value' => '',
+      ),
       'shortlink' => array(
         'value' => '[current-page:url:unaliased]',
+      ),
+      'original-source' => array(
+        'value' => '',
+      ),
+      'prev' => array(
+        'value' => '',
+      ),
+      'next' => array(
+        'value' => '',
+      ),
+      'content-language' => array(
+        'value' => '',
+      ),
+      'geo.position' => array(
+        'value' => '',
+      ),
+      'geo.placename' => array(
+        'value' => '',
+      ),
+      'geo.region' => array(
+        'value' => '',
+      ),
+      'icbm' => array(
+        'value' => '',
+      ),
+      'refresh' => array(
+        'value' => '',
+      ),
+      'revisit-after' => array(
+        'value' => '',
+        'period' => '',
+      ),
+      'pragma' => array(
+        'value' => '',
+      ),
+      'cache-control' => array(
+        'value' => '',
+      ),
+      'expires' => array(
+        'value' => '',
+      ),
+      'dcterms.title' => array(
+        'value' => '[current-page:title]',
+      ),
+      'dcterms.creator' => array(
+        'value' => '',
+      ),
+      'dcterms.subject' => array(
+        'value' => '',
+      ),
+      'dcterms.description' => array(
+        'value' => '',
+      ),
+      'dcterms.publisher' => array(
+        'value' => '',
+      ),
+      'dcterms.contributor' => array(
+        'value' => '',
+      ),
+      'dcterms.date' => array(
+        'value' => '',
+      ),
+      'dcterms.type' => array(
+        'value' => 'Text',
       ),
       'dcterms.format' => array(
         'value' => 'text/html',
@@ -34,20 +142,50 @@ function kada_configuration_feature_metatag_export_default() {
       'dcterms.identifier' => array(
         'value' => '[current-page:url:absolute]',
       ),
-      'dcterms.title' => array(
-        'value' => '[current-page:title]',
+      'dcterms.source' => array(
+        'value' => '',
       ),
-      'dcterms.type' => array(
-        'value' => 'Text',
+      'dcterms.language' => array(
+        'value' => '',
+      ),
+      'dcterms.relation' => array(
+        'value' => '',
+      ),
+      'dcterms.coverage' => array(
+        'value' => '',
+      ),
+      'dcterms.rights' => array(
+        'value' => '',
+      ),
+      'fb:admins' => array(
+        'value' => '',
+      ),
+      'fb:app_id' => array(
+        'value' => '',
+      ),
+      'fb:pages' => array(
+        'value' => '',
+      ),
+      'itemtype' => array(
+        'value' => '',
       ),
       'itemprop:name' => array(
         'value' => '[current-page:title]',
       ),
+      'itemprop:description' => array(
+        'value' => '',
+      ),
+      'itemprop:image' => array(
+        'value' => '',
+      ),
+      'author' => array(
+        'value' => '',
+      ),
+      'publisher' => array(
+        'value' => '',
+      ),
       'og:site_name' => array(
         'value' => '[site:name]',
-      ),
-      'og:title' => array(
-        'value' => '[current-page:title]',
       ),
       'og:type' => array(
         'value' => 'article',
@@ -55,14 +193,275 @@ function kada_configuration_feature_metatag_export_default() {
       'og:url' => array(
         'value' => '[current-page:url:absolute]',
       ),
+      'og:title' => array(
+        'value' => '[current-page:title]',
+      ),
+      'og:determiner' => array(
+        'value' => '',
+      ),
+      'og:description' => array(
+        'value' => '',
+      ),
+      'og:updated_time' => array(
+        'value' => '',
+      ),
+      'og:see_also' => array(
+        'value' => '',
+      ),
+      'og:image' => array(
+        'value' => '',
+      ),
+      'og:image:url' => array(
+        'value' => '',
+      ),
+      'og:image:secure_url' => array(
+        'value' => '',
+      ),
+      'og:image:type' => array(
+        'value' => '',
+      ),
+      'og:image:width' => array(
+        'value' => '',
+      ),
+      'og:image:height' => array(
+        'value' => '',
+      ),
+      'og:latitude' => array(
+        'value' => '',
+      ),
+      'og:longitude' => array(
+        'value' => '',
+      ),
+      'og:street_address' => array(
+        'value' => '',
+      ),
+      'og:locality' => array(
+        'value' => '',
+      ),
+      'og:region' => array(
+        'value' => '',
+      ),
+      'og:postal_code' => array(
+        'value' => '',
+      ),
+      'og:country_name' => array(
+        'value' => '',
+      ),
+      'og:email' => array(
+        'value' => '',
+      ),
+      'og:phone_number' => array(
+        'value' => '',
+      ),
+      'og:fax_number' => array(
+        'value' => '',
+      ),
+      'og:locale' => array(
+        'value' => '',
+      ),
+      'og:locale:alternate' => array(
+        'value' => '',
+      ),
+      'article:author' => array(
+        'value' => '',
+      ),
+      'article:publisher' => array(
+        'value' => '',
+      ),
+      'article:section' => array(
+        'value' => '',
+      ),
+      'article:tag' => array(
+        'value' => '',
+      ),
+      'article:published_time' => array(
+        'value' => '',
+      ),
+      'article:modified_time' => array(
+        'value' => '',
+      ),
+      'article:expiration_time' => array(
+        'value' => '',
+      ),
+      'profile:first_name' => array(
+        'value' => '',
+      ),
+      'profile:last_name' => array(
+        'value' => '',
+      ),
+      'profile:username' => array(
+        'value' => '',
+      ),
+      'profile:gender' => array(
+        'value' => '',
+      ),
+      'og:audio' => array(
+        'value' => '',
+      ),
+      'og:audio:secure_url' => array(
+        'value' => '',
+      ),
+      'og:audio:type' => array(
+        'value' => '',
+      ),
+      'book:author' => array(
+        'value' => '',
+      ),
+      'book:isbn' => array(
+        'value' => '',
+      ),
+      'book:release_date' => array(
+        'value' => '',
+      ),
+      'book:tag' => array(
+        'value' => '',
+      ),
+      'og:video:url' => array(
+        'value' => '',
+      ),
+      'og:video:secure_url' => array(
+        'value' => '',
+      ),
+      'og:video:width' => array(
+        'value' => '',
+      ),
+      'og:video:height' => array(
+        'value' => '',
+      ),
+      'og:video:type' => array(
+        'value' => '',
+      ),
+      'video:actor' => array(
+        'value' => '',
+      ),
+      'video:actor:role' => array(
+        'value' => '',
+      ),
+      'video:director' => array(
+        'value' => '',
+      ),
+      'video:writer' => array(
+        'value' => '',
+      ),
+      'video:duration' => array(
+        'value' => '',
+      ),
+      'video:release_date' => array(
+        'value' => '',
+      ),
+      'video:tag' => array(
+        'value' => '',
+      ),
+      'video:series' => array(
+        'value' => '',
+      ),
       'twitter:card' => array(
         'value' => 'summary',
+      ),
+      'twitter:site' => array(
+        'value' => '',
+      ),
+      'twitter:site:id' => array(
+        'value' => '',
+      ),
+      'twitter:creator' => array(
+        'value' => '',
+      ),
+      'twitter:creator:id' => array(
+        'value' => '',
+      ),
+      'twitter:url' => array(
+        'value' => '[current-page:url:absolute]',
       ),
       'twitter:title' => array(
         'value' => '[current-page:title]',
       ),
-      'twitter:url' => array(
-        'value' => '[current-page:url:absolute]',
+      'twitter:description' => array(
+        'value' => '',
+      ),
+      'twitter:dnt' => array(
+        'value' => '',
+      ),
+      'twitter:image' => array(
+        'value' => '',
+      ),
+      'twitter:image:width' => array(
+        'value' => '',
+      ),
+      'twitter:image:height' => array(
+        'value' => '',
+      ),
+      'twitter:image:alt' => array(
+        'value' => '',
+      ),
+      'twitter:image0' => array(
+        'value' => '',
+      ),
+      'twitter:image1' => array(
+        'value' => '',
+      ),
+      'twitter:image2' => array(
+        'value' => '',
+      ),
+      'twitter:image3' => array(
+        'value' => '',
+      ),
+      'twitter:player' => array(
+        'value' => '',
+      ),
+      'twitter:player:width' => array(
+        'value' => '',
+      ),
+      'twitter:player:height' => array(
+        'value' => '',
+      ),
+      'twitter:player:stream' => array(
+        'value' => '',
+      ),
+      'twitter:player:stream:content_type' => array(
+        'value' => '',
+      ),
+      'twitter:app:country' => array(
+        'value' => '',
+      ),
+      'twitter:app:name:iphone' => array(
+        'value' => '',
+      ),
+      'twitter:app:id:iphone' => array(
+        'value' => '',
+      ),
+      'twitter:app:url:iphone' => array(
+        'value' => '',
+      ),
+      'twitter:app:name:ipad' => array(
+        'value' => '',
+      ),
+      'twitter:app:id:ipad' => array(
+        'value' => '',
+      ),
+      'twitter:app:url:ipad' => array(
+        'value' => '',
+      ),
+      'twitter:app:name:googleplay' => array(
+        'value' => '',
+      ),
+      'twitter:app:id:googleplay' => array(
+        'value' => '',
+      ),
+      'twitter:app:url:googleplay' => array(
+        'value' => '',
+      ),
+      'twitter:label1' => array(
+        'value' => '',
+      ),
+      'twitter:data1' => array(
+        'value' => '',
+      ),
+      'twitter:label2' => array(
+        'value' => '',
+      ),
+      'twitter:data2' => array(
+        'value' => '',
       ),
     ),
   );


### PR DESCRIPTION
> Tried updating the meta-info in BP front-page, but they currently don't seem to be applying. 

Original report: https://wunder.slack.com/archives/C6YALMXK7/p1575284134196500

This issue is the troublemaker: https://www.drupal.org/project/domains_metatag/issues/2556005. There is the suggestion to remove Page title default from Global . Title is provided in every sub-default so it should be safe to remove from Global.

Therefore removed global override for page title (was `[current-page:title] | [site:name]`) to enable domain-based page title via metadata.