### PR TITLE
Increase max_allowed_packet to 256M.

### DIFF
--- a/conf/vagrant.yml
+++ b/conf/vagrant.yml
@@ -69,6 +69,10 @@
             val: 1
           - key: opcache.revalidate_freq
             val: 0
+    
+    # Increase default max_allowed_packet value to avoid MySQL server has gone away error
+    # @see https://www.drupal.org/project/drupal/issues/1014172#comment-4142046
+    max_allowed_packet: 256M
 
     # letsencrypt variables are also used by selfencrypt
     letsencrypt_email: support@example.com


### PR DESCRIPTION
Increase default max_allowed_packet value for Vagrant environment to avoid MySQL server has gone away error during `drush sql-cli < dump.sql` and other high volume tasks.

See also: https://www.drupal.org/project/drupal/issues/1014172#comment-4142046