### PR TITLE
Lando /app mount change

### DIFF
--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -25,6 +25,8 @@ services:
       - /app/.lando/build.sh
       # - /app/build.sh build lando
     overrides:
+      volumes:
+        - ./:/app:consistent
       environment:
         WKV_SITE_ENV: lando
         SAML_MEMCACHE_STORE: memcached


### PR DESCRIPTION
Override default mounting method to 'consistent' (old default) instead of the new default of 'cached'.
This causes a slight performance hit, but makes development easier as Docker no longer caches *all* the files.

I got annoyed at having to do a `lando rebuild -y` after each change in a php file.