### PR TITLE
PORISD-66 - Change file upload to replace existing files.

### DIFF
--- a/drupal/web/sites/all/modules/custom/pori_scald_image/pori_scald_image.module
+++ b/drupal/web/sites/all/modules/custom/pori_scald_image/pori_scald_image.module
@@ -1,30 +1,6 @@
 <?php
 
 /**
- * Implements hook_form_FORM_ID_alter().
- */
-function pori_scald_image_form_scald_atom_add_form_add_alter(&$form, &$form_state, $form_id) {
-  if (!empty($form['file'])) {
-    $form['file']['#plupload_settings']['unique_names'] = 0;
-  }
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
- */
-function pori_scald_image_form_scald_atom_add_form_options_alter(&$form, &$form_state, $form_id) {
-  if (!empty($form['atom0']['scald_thumbnail'])) {
-    $form['atom0']['scald_thumbnail'][LANGUAGE_NONE][0]['#plupload_settings']['unique_names'] = 0;
-  }
-  if (!empty($form['atom0']['scald_file'])) {
-    $form['atom0']['scald_file'][LANGUAGE_NONE][0]['#plupload_settings']['unique_names'] = 0;
-  }
-  if (!empty($form['atom0']['scald_video'])) {
-    $form['atom0']['scald_video'][LANGUAGE_NONE][0]['#plupload_settings']['unique_names'] = 0;
-  }
-}
-
-/**
  * Implements hook_entity_load().
  */
 function pori_scald_image_entity_load($entities, $type) {

--- a/drupal/web/sites/all/modules/custom/pori_scald_image/pori_scald_image.module
+++ b/drupal/web/sites/all/modules/custom/pori_scald_image/pori_scald_image.module
@@ -1,6 +1,30 @@
 <?php
 
 /**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function pori_scald_image_form_scald_atom_add_form_add_alter(&$form, &$form_state, $form_id) {
+  if (!empty($form['file'])) {
+    $form['file']['#plupload_settings']['unique_names'] = 0;
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function pori_scald_image_form_scald_atom_add_form_options_alter(&$form, &$form_state, $form_id) {
+  if (!empty($form['atom0']['scald_thumbnail'])) {
+    $form['atom0']['scald_thumbnail'][LANGUAGE_NONE][0]['#plupload_settings']['unique_names'] = 0;
+  }
+  if (!empty($form['atom0']['scald_file'])) {
+    $form['atom0']['scald_file'][LANGUAGE_NONE][0]['#plupload_settings']['unique_names'] = 0;
+  }
+  if (!empty($form['atom0']['scald_video'])) {
+    $form['atom0']['scald_video'][LANGUAGE_NONE][0]['#plupload_settings']['unique_names'] = 0;
+  }
+}
+
+/**
  * Implements hook_entity_load().
  */
 function pori_scald_image_entity_load($entities, $type) {
@@ -45,3 +69,4 @@ function pori_scald_image_entity_load($entities, $type) {
     }
   }
 }
+


### PR DESCRIPTION
This overrides the Plupload default behaviour of always renaming files to have unique filenames to replacing existing files if uploaded with the same name.

To test:
1) Add a scald atom with a file.
2 ) Edit the recently added atom.
3) Replace the file in the atom with another one with the same name.
4) Open the atom with the View button.
5) Check that the link to the file (in case of a PDF, for example) has the actual filename you uploaded instead of something like "file_0.pdf".